### PR TITLE
add support for async functions.

### DIFF
--- a/bus/bus_test.go
+++ b/bus/bus_test.go
@@ -1,0 +1,56 @@
+package bus
+
+import (
+	"os"
+	"testing"
+
+	"github.com/metal-stack/metal-lib/zapup"
+	"github.com/nsqio/nsq/nsqd"
+)
+
+var (
+	tcpAddress  = "localhost:44150"
+	httpAddress = "localhost:44151"
+	publisher   Publisher
+	consumer    *Consumer
+)
+
+func startupNSQD() error {
+	opts := nsqd.NewOptions()
+	opts.TCPAddress = tcpAddress
+	opts.HTTPAddress = httpAddress
+	opts.DataPath = "/tmp/"
+	nsqd, err := nsqd.New(opts)
+	if err != nil {
+		return err
+	}
+	go func() {
+		err = nsqd.Main()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	consumer, err = NewConsumer(zapup.MustRootLogger(), nil)
+	if err != nil {
+		return err
+	}
+	consumer.With(NSQDs(tcpAddress))
+
+	cfg := &PublisherConfig{
+		TCPAddress:   tcpAddress,
+		HTTPEndpoint: httpAddress,
+	}
+
+	publisher, err = NewPublisher(zapup.MustRootLogger(), cfg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	_ = startupNSQD()
+	code := m.Run()
+	os.Exit(code)
+}

--- a/bus/doc.go
+++ b/bus/doc.go
@@ -1,0 +1,14 @@
+/*
+  Package bus implements a thin wrapper around nsq so that you can create publishers for topics and
+  consumers for channels.
+
+  `Consumer` and `Publisher` are thin wrappers around the basic concept of
+  nsq with small additions.
+
+  A `Function` abstracts an asynchronous function which will be called by marshalling the
+  parameters as JSON and invoke the corresponding function with nsq. You can start many services
+  which implement the same function (identified by its name), so you will have something like a
+  balancing. Note: As the functions are asynchronuous, you cannot return a result. Only errors
+  are used to signal if the function was successfull.
+*/
+package bus

--- a/bus/eventbus.go
+++ b/bus/eventbus.go
@@ -38,6 +38,7 @@ type Receiver func(interface{}) error
 // A Consumer wraps the base configuration for the nsq connection
 type Consumer struct {
 	lookupds []string
+	nsqds    []string
 	config   *nsq.Config
 	log      *zap.Logger
 	logLevel nsq.LogLevel
@@ -88,6 +89,13 @@ func LogLevel(v Level) Option {
 
 		c.logLevel = l
 
+		return c
+	}
+}
+
+func NSQDs(nsqds ...string) Option {
+	return func(c *Consumer) *Consumer {
+		c.nsqds = nsqds
 		return c
 	}
 }
@@ -262,6 +270,9 @@ func (cr *ConsumerRegistration) Consume(paramProto interface{}, recv Receiver, c
 	cr.c.AddConcurrentHandlers(nsq.HandlerFunc(tw.handleWithTimeout), concurrent)
 	cr.connected = true
 
+	if cr.consumer.nsqds != nil {
+		return cr.c.ConnectToNSQDs(cr.consumer.nsqds)
+	}
 	return cr.c.ConnectToNSQLookupds(cr.consumer.lookupds)
 }
 

--- a/bus/functools.go
+++ b/bus/functools.go
@@ -1,0 +1,65 @@
+package bus
+
+import "fmt"
+
+// Endpoints couples a consumer and a publisher to a single entity.
+type Endpoints struct {
+	consumer  *Consumer
+	publisher Publisher
+}
+
+// NewEndpoints creates the Endpoints for the given publisher and consumer.
+func NewEndpoints(consumer *Consumer, publisher Publisher) *Endpoints {
+	return &Endpoints{
+		consumer:  consumer,
+		publisher: publisher,
+	}
+}
+
+// A Func is a function with an argument which can return an error when it fails.
+type Func func(interface{}) error
+
+// A Function encapsulates a Func which can be called with an argument. The invocation will be delegated through
+// nsq so multiple instances of the same function can run in different processes. Only one of them
+// will be invoked.
+type Function struct {
+	endpoints *Endpoints
+	cr        *ConsumerRegistration
+	fn        Func
+	name      string
+}
+
+type funcParam struct {
+	Parameter interface{} `json:"parameter"`
+}
+
+// Function creates a Function from the with the given endpoints. The name of the function will be a
+// distributed selector for the given go function. So every function which is registered with the same
+// name can receive the invocation inside the cluster.
+func (e *Endpoints) Function(name string, fn Func) (*Function, error) {
+	reg, err := e.consumer.Register(name, "function#ephemeral")
+	if err != nil {
+		return nil, fmt.Errorf("cannot register consumer for function %q: %w", name, err)
+	}
+	cb := &Function{
+		endpoints: e,
+		cr:        reg,
+		fn:        fn,
+		name:      name,
+	}
+	if err = reg.Consume(funcParam{}, cb.receive, 5); err != nil {
+		return nil, fmt.Errorf("cannot consume: %w", err)
+	}
+	return cb, nil
+}
+
+func (f *Function) receive(par interface{}) error {
+	fp := par.(*funcParam)
+	return f.fn(fp.Parameter)
+}
+
+// MustSucceed invokes the function with no limit. So nsq will invoke the connected go function
+// until no error is returned.
+func (f *Function) MustSucceed(arg interface{}) error {
+	return f.endpoints.publisher.Publish(f.name, funcParam{Parameter: arg})
+}

--- a/bus/functools_test.go
+++ b/bus/functools_test.go
@@ -1,0 +1,69 @@
+package bus
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestFunctionHelloWorld(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	res := ""
+	e := NewEndpoints(consumer, publisher)
+	f, err := e.Function("helloworld", func(arg interface{}) error {
+		res = fmt.Sprintf("%v", arg)
+		wg.Done()
+		return nil
+	})
+	if err != nil {
+		t.Errorf("cannot create function, %v", err)
+	}
+
+	value := "Hello world"
+	err = f.MustSucceed(value)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("function must succeed, %v", err)
+	}
+
+	if res != value {
+		t.Errorf("result is %q, but should be %q", res, value)
+	}
+}
+
+func TestFunctionReplay(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	res := ""
+	num := 0
+	retries := 1
+	e := NewEndpoints(consumer, publisher)
+	f, err := e.Function("helloworld-replay", func(arg interface{}) error {
+		if num < retries {
+			num += 1
+			return fmt.Errorf("not on the first run: %d", num)
+		}
+		res = fmt.Sprintf("%v: %d", arg, num)
+		wg.Done()
+		return nil
+	})
+	if err != nil {
+		t.Errorf("cannot create function, %v", err)
+	}
+
+	value := "Hello world"
+	err = f.MustSucceed(value)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("function must succeed, %v", err)
+	}
+
+	if res != fmt.Sprintf("%s: %d", value, retries) {
+		t.Errorf("result is %q, but should be %q", res, value)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nsqio/go-nsq v1.0.8
+	github.com/nsqio/nsq v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,12 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
+github.com/bitly/timer_metrics v0.0.0-20170606164300-b1c65ca7ae62/go.mod h1:EJqiy/5FjJk5tEOxXhnxvFijOmeB5ka1D2fvqHOXUXA=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
+github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
 github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -123,6 +129,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -140,6 +147,9 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/judwhite/go-svc v1.0.0/go.mod h1:EeMSAFO3mLgEQfcvnZ50JDG0O1uQlagpAbMS6talrXE=
+github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
+github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -182,8 +192,14 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mreiferson/go-options v0.0.0-20190302015348-0c63f026bcd6/go.mod h1:zHtCks/HQvOt8ATyfwVe3JJq2PPuImzXINPRTC03+9w=
+github.com/nsqio/go-diskqueue v0.0.0-20180306152900-74cfbc9de839 h1:nZ0z0haJRzCXAWH9Jl+BUnfD2n2MCSbGRSl8VBX+zR0=
+github.com/nsqio/go-diskqueue v0.0.0-20180306152900-74cfbc9de839/go.mod h1:AYinRDfdKMmVKTPI8wOcLgjcw2pTS3jo8fib1VxOzsE=
+github.com/nsqio/go-nsq v1.0.7/go.mod h1:XP5zaUs3pqf+Q71EqUJs3HYfBIqfK6G83WQMdNN+Ito=
 github.com/nsqio/go-nsq v1.0.8 h1:3L2F8tNLlwXXlp2slDUrUWSBn2O3nMh8R1/KEDFTHPk=
 github.com/nsqio/go-nsq v1.0.8/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
+github.com/nsqio/nsq v1.2.0 h1:inbQG4LAl8PpMMZAUi0FhLvjQ+57wOfPzWczVFdng7Q=
+github.com/nsqio/nsq v1.2.0/go.mod h1:hrx5K/ukZ1mebJBTNpv6og98a7I5zR279qjYNPdgdL0=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
@@ -276,6 +292,7 @@ golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
A Function is a block of code which can return an error if it is not
successful. To call this function, one can use MustSucceed which tells
nsq to invoke the handler until the function itself returns no error.

The publisher and consumer are both implemented by the using process so
this function can be used to async call a function. If your process is
running inside a cluster it is possible to distribute the invocation to
other instances.

I think we will need such a functionality for `metal-api` to asynchronously delete machines (or other independent entities).