### PR TITLE
Implements #10 kubeconfig/auth: let client-apps choose contextName for storing credentials

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -486,18 +486,18 @@ func openBrowser(url string) error {
 	return nil
 }
 
-//KubeConfgiHandlerOption func for specifying options
-type KubeConfgiHandlerOption func(c *updateKubeConfig)
+// KubeConfigHandlerOption func for specifying options
+type KubeConfigHandlerOption func(c *updateKubeConfig)
 
-//WithContextName sets the context-name
-func WithContextName(contextName string) KubeConfgiHandlerOption {
+// WithContextName sets the context-name
+func WithContextName(contextName string) KubeConfigHandlerOption {
 	return func(c *updateKubeConfig) {
 		c.contextName = contextName
 	}
 }
 
 // NewUpdateKubeConfigHandler writes the TokenInfo to file and prints a message to the given writer, may be nil
-func NewUpdateKubeConfigHandler(kubeConfig string, writer io.Writer, opts ...KubeConfgiHandlerOption) TokenHandlerFunc {
+func NewUpdateKubeConfigHandler(kubeConfig string, writer io.Writer, opts ...KubeConfigHandlerOption) TokenHandlerFunc {
 	u := &updateKubeConfig{
 		kubeConfig:      kubeConfig,
 		contextName:     cloudContext,

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,8 +1,15 @@
 package auth
 
 import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 )
+
+const testCloudContextName123 = "ctx123"
 
 func Test_IssuerValidation(t *testing.T) {
 	err := OIDCFlow(Config{})
@@ -39,4 +46,58 @@ func Test_TokenHandlerValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected err")
 	}
+}
+
+func Test_NewUpdateKubeConfigHandler(t *testing.T) {
+	tokenInfo := TokenInfo{
+		IDToken:      "123",
+		RefreshToken: "456",
+		TokenClaims:  claim{},
+		IssuerConfig: IssuerConfig{},
+	}
+
+	file, err := ioutil.TempFile("", "prefix")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	var b bytes.Buffer
+	thf := NewUpdateKubeConfigHandler(file.Name(), &b)
+	err = thf(tokenInfo)
+	assert.NoError(t, err)
+
+	_, err = GetAuthContext(file.Name(), "xyz")
+	assert.EqualError(t, err, "no contexts, name=xyz found")
+
+	authCtx, err := GetAuthContext(file.Name(), cloudContext)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", authCtx.IDToken)
+}
+
+func Test_NewUpdateKubeConfigHandlerWithContext(t *testing.T) {
+	tokenInfo := TokenInfo{
+		IDToken:      "123",
+		RefreshToken: "456",
+		TokenClaims:  claim{},
+		IssuerConfig: IssuerConfig{},
+	}
+
+	file, err := ioutil.TempFile("", "prefix")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	var b bytes.Buffer
+	thf := NewUpdateKubeConfigHandler(file.Name(), &b, WithContextName("ctx123"))
+	err = thf(tokenInfo)
+	assert.NoError(t, err)
+
+	_, err = GetAuthContext(file.Name(), "cloudctl-xyz")
+	assert.EqualError(t, err, "no contexts, name=cloudctl-xyz found")
+
+	authCtx, err := GetAuthContext(file.Name(), testCloudContextName123)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", authCtx.IDToken)
 }

--- a/auth/testdata/UEMCexpectedProdConfig
+++ b/auth/testdata/UEMCexpectedProdConfig
@@ -1,0 +1,45 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /home/test/.minikube/ca.crt
+    server: https://192.168.39.76:8443
+  name: testcluster
+contexts:
+- context:
+    cluster: ""
+    user: other-email@other-provider.de
+  name: cloudctl-prod
+- context:
+    cluster: testcluster
+    user: developer
+  name: mycluster
+current-context: mycluster
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    client-certificate: /tmp/fake-cert-file
+    client-key: /tmp/fake-key-file
+- name: email@provider.de
+  user:
+    auth-provider:
+      config:
+        client-id: clientId_abcd
+        client-secret: clientSecret_123123
+        id-token: abcd4711
+        idp-certificate-authority: /my/ca
+        idp-issuer-url: the_issuer
+        refresh-token: refresh234
+      name: oidc
+- name: other-email@other-provider.de
+  user:
+    auth-provider:
+      config:
+        client-id: clientId_abcd
+        client-secret: clientSecret_123123
+        id-token: cdefg
+        idp-certificate-authority: /my/ca
+        idp-issuer-url: the_issuer
+        refresh-token: refresh987
+      name: oidc

--- a/auth/testdata/UEMCgivenProdConfig
+++ b/auth/testdata/UEMCgivenProdConfig
@@ -1,0 +1,34 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /home/test/.minikube/ca.crt
+    server: https://192.168.39.76:8443
+  name: testcluster
+contexts:
+- context:
+    cluster: ""
+    user: email@provider.de
+  name: cloudctl-prod
+- context:
+    cluster: testcluster
+    user: developer
+  name: mycluster
+current-context: mycluster
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    client-certificate: /tmp/fake-cert-file
+    client-key: /tmp/fake-key-file
+- name: email@provider.de
+  user:
+    auth-provider:
+      config:
+        client-id: clientId_abcd
+        client-secret: clientSecret_123123
+        id-token: abcd4711
+        idp-certificate-authority: /my/ca
+        idp-issuer-url: the_issuer
+        refresh-token: refresh234
+      name: oidc

--- a/auth/testdata/config-bare-with-suffix
+++ b/auth/testdata/config-bare-with-suffix
@@ -1,0 +1,34 @@
+apiVersion: v1
+clusters:
+contexts:
+- context:
+    user: myUserId
+  name: cloudctl-prod
+- context:
+    user: myUserIdDev
+  name: cloudctl-dev
+kind: Config
+preferences: {}
+users:
+- name: myUserId
+  user:
+    auth-provider:
+      config:
+        client-id: cli-id
+        client-secret: SomeRandomString
+        id-token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+        idp-certificate-authority: ""
+        idp-issuer-url: https://dex.test.metal-stack.io/dex
+        refresh-token: Chl4aHFmNWkzcTRiZGRrd2RmcDRvNHNjc3hqEhlldXFvem9mN2QycHFieGF0Zms3eGhrendm
+      name: oidc
+- name: myUserIdDev
+  user:
+    auth-provider:
+      config:
+        client-id: cli-id-dev
+        client-secret: SomeRandomStringDev
+        id-token: Dev-ID-Token
+        idp-certificate-authority: ""
+        idp-issuer-url: https://dex.dev.metal-stack.io/dex
+        refresh-token: Dev-Refresh-Token
+      name: oidc


### PR DESCRIPTION
* generalized kubeconfig handling regarding context
* moved specifics from kubeconfig.go to opinionated auth.go

