### PR TITLE
Add default external network tag.

### DIFF
--- a/pkg/tag/network.go
+++ b/pkg/tag/network.go
@@ -1,0 +1,6 @@
+package tag
+
+const (
+	// NetworkDefaultExternal indicates a network that can serve as a default for IP allocations
+	NetworkDefaultExternal = "network.metal-stack.io/default-external"
+)


### PR DESCRIPTION
References https://github.com/metal-stack/metal-ccm/pull/17 (solving issue as proposed in https://github.com/metal-stack/metal-ccm/issues/16).