### PR TITLE
Implement go-openapi validation interface for httperrors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful-openapi/v2 v2.2.1
 	github.com/emicklei/go-restful/v3 v3.3.1
+	github.com/go-openapi/runtime v0.19.21
+	github.com/go-openapi/strfmt v0.19.5
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835

--- a/httperrors/error.go
+++ b/httperrors/error.go
@@ -3,6 +3,8 @@ package httperrors
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/go-openapi/strfmt"
 )
 
 // HTTPErrorResponse is returned in case of functional errors.
@@ -113,4 +115,8 @@ func UnknownError(err error) *HTTPErrorResponse {
 // UnconventionalError creates a new error with a given error message for a response that did not follow the internal error convention. Convenience Method.
 func UnconventionalError(err error) *HTTPErrorResponse {
 	return NewHTTPError(http.StatusInternalServerError, fmt.Errorf("unexpected error: client response does not follow internal error convention: %v", err.Error()))
+}
+
+func (h *HTTPErrorResponse) Validate(formats strfmt.Registry) error {
+	return nil
 }


### PR DESCRIPTION
References https://github.com/metal-stack/metal-go/issues/46.