### PR TITLE
Implement text unmarshaler interface for HTTP error response.

### DIFF
--- a/httperrors/error.go
+++ b/httperrors/error.go
@@ -35,6 +35,10 @@ func (h *HTTPErrorResponse) Error() string {
 	return fmt.Sprintf("%s (%d)", h.Message, h.StatusCode)
 }
 
+func (h *HTTPErrorResponse) UnmarshalText(text []byte) error {
+	return fmt.Errorf("endpoint returned plaintext response unexpectedly:\n%s", string(text))
+}
+
 // NotFound creates a new notfound error with a given error message. Convenience Method.
 func NotFound(err error) *HTTPErrorResponse {
 	return NewHTTPError(http.StatusNotFound, err)


### PR DESCRIPTION
This allows us to even show unexpected plaintext responses from API endpoints.

Before:

```
CLOUDCTL_URL=http://google.de cloudctl cluster ls
Error:  (0) (*httperrors.HTTPErrorResponse) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
```

With these changes:

```
$ CLOUDCTL_URL=http://google.de cloudctl cluster ls
Error: text consumer: endpoint returned plaintext response unexpectedly: 
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That's an error.</ins>