### PR TITLE
Implement text marshaller interface properly.

### DIFF
--- a/httperrors/error_test.go
+++ b/httperrors/error_test.go
@@ -1,0 +1,51 @@
+package httperrors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHTTPErrorResponse_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    []byte
+		want    *HTTPErrorResponse
+		wantErr error
+	}{
+		{
+			name: "unmarshals empty json",
+			text: []byte("{}"),
+			want: &HTTPErrorResponse{},
+		},
+		{
+			name: "unmarshals json response",
+			text: []byte(`{"statuscode": 300, "message":"test"}`),
+			want: &HTTPErrorResponse{
+				StatusCode: 300,
+				Message:    "test",
+			},
+		},
+		{
+			name:    "errors on invalid json",
+			text:    []byte("nojson"),
+			wantErr: fmt.Errorf("endpoint did not return a json response:\nnojson"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HTTPErrorResponse{}
+			err := h.UnmarshalText(tt.text)
+			if tt.wantErr != nil {
+				if tt.wantErr.Error() != err.Error() {
+					t.Errorf("HTTPErrorResponse.UnmarshalText() want = %s, got = %s", err.Error(), tt.wantErr.Error())
+				}
+				return
+			}
+			if diff := cmp.Diff(h, tt.want); diff != "" {
+				t.Errorf("HTTPErrorResponse.UnmarshalText() diff = %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If you don't do this correctly, JSON marshalling will have trouble. Fixes cloud-api tests.