### PR TITLE
Implements #28 Support claim "preferred_username" as username for generic oidc and Issuer & Subject

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -109,15 +109,24 @@ func (a *app) Consolef(format string, args ...interface{}) {
 }
 
 type claim struct {
-	Iss           string      `json:"iss"`
-	Sub           string      `json:"sub"`
-	Aud           interface{} `json:"aud"` // since it depends on the scopes if aud is a string or []string
-	Exp           int         `json:"exp"`
-	Iat           int         `json:"iat"`
-	AtHash        string      `json:"at_hash"`
-	Email         string      `json:"email"`
-	EmailVerified bool        `json:"email_verified"`
-	Name          string      `json:"name"`
+	Iss               string      `json:"iss"`
+	Sub               string      `json:"sub"`
+	Aud               interface{} `json:"aud"` // since it depends on the scopes if aud is a string or []string
+	Exp               int         `json:"exp"`
+	Iat               int         `json:"iat"`
+	AtHash            string      `json:"at_hash"`
+	Email             string      `json:"email"`
+	EmailVerified     bool        `json:"email_verified"`
+	Name              string      `json:"name"`
+	PreferredUsername string      `json:"preferred_username"`
+}
+
+// Username returns the username, taken from preferredUsername or name.
+func (c claim) Username() string {
+	if c.PreferredUsername != "" {
+		return c.PreferredUsername
+	}
+	return c.Name
 }
 
 // OIDCFlow validates the given config and starts the OIDC-Flow "response_type=code"
@@ -461,7 +470,7 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	renderToken(w, rawIDToken, token.RefreshToken, buff.Bytes(), a.config.SuccessMessage, a.config.Debug)
 
-	a.config.Log.Debug("Login Succeeded", zap.String("username", claims.Name))
+	a.config.Log.Debug("Login Succeeded", zap.String("username", claims.Username()))
 	a.config.Log.Debug("Login-Data", zap.String("token", rawIDToken), zap.String("Refresh Token", token.RefreshToken), zap.String("Claims", string(rawClaims)))
 
 	go func() {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -29,7 +29,7 @@ import (
 const cloudContext = "cloudctl"
 
 var DexScopes = []string{"groups", "openid", "profile", "email", "federated:id"}
-var GenericScopes = []string{"groups", "openid", "profile", "email"}
+var GenericScopes = []string{"openid", "profile", "email"}
 
 // Config for parametrization
 type Config struct {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -52,7 +52,7 @@ func Test_NewUpdateKubeConfigHandler(t *testing.T) {
 	tokenInfo := TokenInfo{
 		IDToken:      "123",
 		RefreshToken: "456",
-		TokenClaims:  claim{},
+		TokenClaims:  Claims{},
 		IssuerConfig: IssuerConfig{},
 	}
 
@@ -79,7 +79,7 @@ func Test_NewUpdateKubeConfigHandlerWithContext(t *testing.T) {
 	tokenInfo := TokenInfo{
 		IDToken:      "123",
 		RefreshToken: "456",
-		TokenClaims:  claim{},
+		TokenClaims:  Claims{},
 		IssuerConfig: IssuerConfig{},
 	}
 

--- a/auth/kubeconfig.go
+++ b/auth/kubeconfig.go
@@ -29,7 +29,7 @@ const (
 type UserIDExtractor func(tokenInfo TokenInfo) string
 
 func ExtractName(tokenInfo TokenInfo) string {
-	return tokenInfo.TokenClaims.Name
+	return tokenInfo.TokenClaims.Username()
 }
 
 func ExtractEMail(tokenInfo TokenInfo) string {

--- a/auth/kubeconfig.go
+++ b/auth/kubeconfig.go
@@ -33,7 +33,7 @@ func ExtractName(tokenInfo TokenInfo) string {
 }
 
 func ExtractEMail(tokenInfo TokenInfo) string {
-	return tokenInfo.TokenClaims.Email
+	return tokenInfo.TokenClaims.EMail
 }
 
 // UpdateKubeConfig saves the given tokenInfo in the given kubeConfig. The given path to kubeconfig is preferred,
@@ -85,7 +85,7 @@ func UpdateKubeConfigContext(kubeConfig string, tokenInfo TokenInfo, userIDExtra
 		"client-secret":             tokenInfo.ClientSecret,
 		"id-token":                  tokenInfo.IDToken,
 		"refresh-token":             tokenInfo.RefreshToken,
-		"idp-issuer-url":            tokenInfo.TokenClaims.Iss,
+		"idp-issuer-url":            tokenInfo.TokenClaims.Issuer,
 		"idp-certificate-authority": tokenInfo.IssuerCA,
 	}
 

--- a/auth/kubeconfig_test.go
+++ b/auth/kubeconfig_test.go
@@ -16,6 +16,46 @@ const testCloudContextName = "cloudctl"
 const testCloudContextNameDev = "cloudctl-dev"
 const testCloudContextNameProd = "cloudctl-prod"
 
+func Test_ExtractUsername(t *testing.T) {
+	type tst struct {
+		t    TokenInfo
+		want string
+	}
+	tests := []tst{
+		{
+			t: TokenInfo{
+				TokenClaims: claim{
+					Name: "Erich",
+				},
+				IssuerConfig: IssuerConfig{},
+			},
+			want: "Erich",
+		},
+		{
+			t: TokenInfo{
+				TokenClaims: claim{
+					Name:              "Erich",
+					PreferredUsername: "xyz123",
+				},
+				IssuerConfig: IssuerConfig{},
+			},
+			want: "xyz123",
+		},
+		{
+			t: TokenInfo{
+				TokenClaims: claim{
+					PreferredUsername: "xyz123",
+				},
+				IssuerConfig: IssuerConfig{},
+			},
+			want: "xyz123",
+		},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, ExtractName(tt.t))
+	}
+}
+
 func Test_GetCurrentUser(t *testing.T) {
 
 	tests := []test{
@@ -170,10 +210,11 @@ var demoToken = TokenInfo{
 		IssuerCA:     "/my/ca",
 	},
 	TokenClaims: claim{
-		Iss:   "the_issuer",
-		Email: "email@provider.de",
-		Sub:   "the_sub",
-		Name:  "user001",
+		Iss:               "the_issuer",
+		Email:             "email@provider.de",
+		Sub:               "the_sub",
+		Name:              "Ernst Mail",
+		PreferredUsername: "user001",
 	},
 	IDToken:      "abcd4711",
 	RefreshToken: "refresh234",
@@ -265,7 +306,7 @@ func TestUpdateUserWithNameExtractorNewFile(t *testing.T) {
 		t.Fatalf("error reading back user: %v", err)
 	}
 
-	asserter.Equal(authContext.User, demoToken.TokenClaims.Name, "User")
+	asserter.Equal(authContext.User, demoToken.TokenClaims.Username(), "User")
 	asserter.Equal(authContext.IDToken, demoToken.IDToken, "IDToken")
 	asserter.Equal(authContext.ClientID, demoToken.ClientID, "ClientID")
 	asserter.Equal(authContext.ClientSecret, demoToken.ClientSecret, "ClientSecret")

--- a/auth/kubeconfig_test.go
+++ b/auth/kubeconfig_test.go
@@ -24,8 +24,10 @@ func Test_ExtractUsername(t *testing.T) {
 	tests := []tst{
 		{
 			t: TokenInfo{
-				TokenClaims: claim{
-					Name: "Erich",
+				TokenClaims: Claims{
+					Name:              "Erich",
+					PreferredUsername: "",
+					Roles:             nil,
 				},
 				IssuerConfig: IssuerConfig{},
 			},
@@ -33,7 +35,7 @@ func Test_ExtractUsername(t *testing.T) {
 		},
 		{
 			t: TokenInfo{
-				TokenClaims: claim{
+				TokenClaims: Claims{
 					Name:              "Erich",
 					PreferredUsername: "xyz123",
 				},
@@ -43,7 +45,7 @@ func Test_ExtractUsername(t *testing.T) {
 		},
 		{
 			t: TokenInfo{
-				TokenClaims: claim{
+				TokenClaims: Claims{
 					PreferredUsername: "xyz123",
 				},
 				IssuerConfig: IssuerConfig{},
@@ -209,12 +211,13 @@ var demoToken = TokenInfo{
 		IssuerURL:    "the_issuer",
 		IssuerCA:     "/my/ca",
 	},
-	TokenClaims: claim{
-		Iss:               "the_issuer",
-		Email:             "email@provider.de",
-		Sub:               "the_sub",
-		Name:              "Ernst Mail",
-		PreferredUsername: "user001",
+	TokenClaims: Claims{
+		Issuer:            "the_issuer",
+		Subject:           "the_sub",
+		EMail:             "email@provider.de",
+		Name:              "user001",
+		PreferredUsername: "",
+		Roles:             nil,
 	},
 	IDToken:      "abcd4711",
 	RefreshToken: "refresh234",
@@ -227,11 +230,11 @@ var demoToken2 = TokenInfo{
 		IssuerURL:    "the_issuer",
 		IssuerCA:     "/my/ca",
 	},
-	TokenClaims: claim{
-		Iss:   "the_issuer",
-		Email: "other-email@other-provider.de",
-		Sub:   "the_sub",
-		Name:  "user002",
+	TokenClaims: Claims{
+		Issuer:  "the_issuer",
+		Subject: "the_sub",
+		EMail:   "other-email@other-provider.de",
+		Name:    "user002",
 	},
 	IDToken:      "cdefg",
 	RefreshToken: "refresh987",
@@ -266,7 +269,7 @@ func TestUpdateUserNewFile(t *testing.T) {
 		t.Fatalf("error reading back user: %v", err)
 	}
 
-	asserter.Equal(authContext.User, demoToken.TokenClaims.Email, "User")
+	asserter.Equal(authContext.User, demoToken.TokenClaims.EMail, "User")
 	asserter.Equal(authContext.IDToken, demoToken.IDToken, "IDToken")
 	asserter.Equal(authContext.AuthProviderName, "oidc", "AuthProvider")
 	asserter.Equal(authContext.Ctx, testCloudContextName, "Context")
@@ -322,7 +325,7 @@ func TestLoadExistingConfigWithOIDC(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, authContext.User, demoToken.TokenClaims.Email, "User")
+	require.Equal(t, authContext.User, demoToken.TokenClaims.EMail, "User")
 	require.Equal(t, authContext.IDToken, demoToken.IDToken, "IDToken")
 	require.Equal(t, authContext.ClientID, demoToken.ClientID, "ClientID")
 	require.Equal(t, authContext.ClientSecret, demoToken.ClientSecret, "ClientSecret")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
 	github.com/json-iterator/go v1.1.10 // indirect
-	github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a
+	github.com/metal-stack/security v0.5.2
 	github.com/metal-stack/v v1.0.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
 	github.com/json-iterator/go v1.1.10 // indirect
-	github.com/metal-stack/security v0.5.1
+	github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a
 	github.com/metal-stack/v v1.0.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,10 +293,8 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/metal-stack/security v0.5.1 h1:hK0KgyeTdDDxFucZiO7TeJ3MeZkK5vUPADKcXPkBjHU=
-github.com/metal-stack/security v0.5.1/go.mod h1:t7P93F6/iSDR729OS/3x5t69ewBCsHUYqRVaHb5nxjc=
-github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a h1:m2e8jaU56jMyAO7iMFWgss3hh/VF8c0VOv5V4COHAv4=
-github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a/go.mod h1:t7P93F6/iSDR729OS/3x5t69ewBCsHUYqRVaHb5nxjc=
+github.com/metal-stack/security v0.5.2 h1:bOXV1sKCPSuSL+8J8Oz0uP1XvVnqGhrQxPqJ+4Ldb/s=
+github.com/metal-stack/security v0.5.2/go.mod h1:t7P93F6/iSDR729OS/3x5t69ewBCsHUYqRVaHb5nxjc=
 github.com/metal-stack/v v1.0.2 h1:IGtLAGtazQd8r0i/5+YNjBJUEIZYrbVxynY9EXrlTV4=
 github.com/metal-stack/v v1.0.2/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/metal-stack/security v0.5.1 h1:hK0KgyeTdDDxFucZiO7TeJ3MeZkK5vUPADKcXPkBjHU=
 github.com/metal-stack/security v0.5.1/go.mod h1:t7P93F6/iSDR729OS/3x5t69ewBCsHUYqRVaHb5nxjc=
+github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a h1:m2e8jaU56jMyAO7iMFWgss3hh/VF8c0VOv5V4COHAv4=
+github.com/metal-stack/security v0.5.2-0.20210316202810-bd580f0e999a/go.mod h1:t7P93F6/iSDR729OS/3x5t69ewBCsHUYqRVaHb5nxjc=
 github.com/metal-stack/v v1.0.2 h1:IGtLAGtazQd8r0i/5+YNjBJUEIZYrbVxynY9EXrlTV4=
 github.com/metal-stack/v v1.0.2/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/jwt/sec/plugin.go
+++ b/jwt/sec/plugin.go
@@ -42,7 +42,7 @@ func genericOidcExtractUser(ic *security.IssuerConfig, claims *security.GenericO
 	}
 
 	usr := security.User{
-		Name:   claims.Name,
+		Name:   claims.PreferredUsername,
 		EMail:  claims.EMail,
 		Groups: grps,
 		Tenant: ic.Tenant,

--- a/jwt/sec/plugin_test.go
+++ b/jwt/sec/plugin_test.go
@@ -2,6 +2,7 @@ package sec
 
 import (
 	"errors"
+	"github.com/google/go-cmp/cmp"
 	"github.com/metal-stack/metal-lib/jwt/grp"
 	"github.com/metal-stack/security"
 	"github.com/stretchr/testify/assert"
@@ -214,9 +215,10 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 					Claims: jwt.Claims{
 						Audience: jwt.Audience{"audience"},
 					},
-					Roles: []string{},
-					EMail: "hans@demo.de",
-					Name:  "hans",
+					Roles:             []string{},
+					EMail:             "hans@demo.de",
+					Name:              "Hans Meiser",
+					PreferredUsername: "xyz4711",
 				},
 			},
 			wantErr: errors.New("invalid directoryType xx"),
@@ -236,14 +238,15 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 					Claims: jwt.Claims{
 						Audience: jwt.Audience{"audience"},
 					},
-					Roles: []string{"tnnt_kaas-all-all-admin"},
-					EMail: "hans@demo.de",
-					Name:  "hans",
+					Roles:             []string{"tnnt_kaas-all-all-admin"},
+					EMail:             "hans@demo.de",
+					Name:              "Hans Meiser",
+					PreferredUsername: "xyz4711",
 				},
 			},
 			wantUser: &security.User{
 				EMail: "hans@demo.de",
-				Name:  "hans",
+				Name:  "xyz4711",
 				Groups: []security.ResourceAccess{
 					security.ResourceAccess("kaas-all-all-admin"),
 				},
@@ -266,14 +269,15 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 					Claims: jwt.Claims{
 						Audience: jwt.Audience{"audience"},
 					},
-					Roles: []string{"TnRg_Srv_Appkaas-all-all-admin_Full"},
-					EMail: "hans@demo.de",
-					Name:  "hans",
+					Roles:             []string{"TnRg_Srv_Appkaas-all-all-admin_Full"},
+					EMail:             "hans@demo.de",
+					Name:              "Hans Meiser",
+					PreferredUsername: "xyz4711",
 				},
 			},
 			wantUser: &security.User{
 				EMail: "hans@demo.de",
-				Name:  "hans",
+				Name:  "xyz4711",
 				Groups: []security.ResourceAccess{
 					security.ResourceAccess("kaas-all-all-admin"),
 				},
@@ -306,13 +310,14 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 						"malfrmd_kaas-all-all",
 						"malformed",
 					},
-					EMail: "hans@demo.de",
-					Name:  "hans",
+					EMail:             "hans@demo.de",
+					Name:              "Hans Meiser",
+					PreferredUsername: "xyz4711",
 				},
 			},
 			wantUser: &security.User{
 				EMail: "hans@demo.de",
-				Name:  "hans",
+				Name:  "xyz4711",
 				Groups: []security.ResourceAccess{
 					security.ResourceAccess("k8s-all-all-group1"),
 					security.ResourceAccess("maas-all-all-maasgroup1"),
@@ -356,13 +361,14 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 						"malfrmd_kaas-all-all",
 						"malformed",
 					},
-					EMail: "hans@demo.de",
-					Name:  "hans",
+					EMail:             "hans@demo.de",
+					Name:              "Hans Meiser",
+					PreferredUsername: "xyz4711",
 				},
 			},
 			wantUser: &security.User{
 				EMail: "hans@demo.de",
-				Name:  "hans",
+				Name:  "xyz4711",
 				Groups: []security.ResourceAccess{
 					security.ResourceAccess("k8s-ddd#all-all-group1"),
 					security.ResourceAccess("maas-all-all-maasgroup1"),
@@ -394,7 +400,8 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(gotUser, tt.wantUser) {
-				t.Errorf("ExtractUserProcessGroups() gotUser = %v, want %v", gotUser, tt.wantUser)
+				diff := cmp.Diff(tt.wantUser, gotUser)
+				t.Errorf("ExtractUserProcessGroups() gotUser = %v, want %v, diff %s", gotUser, tt.wantUser, diff)
 			}
 
 			for i := range tt.wantGroupsOnBehalf {

--- a/jwt/sec/token.go
+++ b/jwt/sec/token.go
@@ -67,10 +67,12 @@ func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *security.Cl
 	}
 
 	user := &security.User{
-		Name:   parsedClaims.Name,
-		EMail:  parsedClaims.EMail,
-		Groups: res,
-		Tenant: tenant,
+		Issuer:  parsedClaims.Issuer,
+		Subject: parsedClaims.Subject,
+		Name:    parsedClaims.Name,
+		EMail:   parsedClaims.EMail,
+		Groups:  res,
+		Tenant:  tenant,
 	}
 
 	if err != nil {

--- a/jwt/sec/token.go
+++ b/jwt/sec/token.go
@@ -2,6 +2,7 @@ package sec
 
 import (
 	"fmt"
+	"github.com/metal-stack/metal-lib/auth"
 	"github.com/metal-stack/metal-lib/jwt/grp"
 	"github.com/metal-stack/security"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -32,9 +33,9 @@ func (p *Plugin) ParseTokenUnvalidated(token string) (*security.User, *security.
 // ParseTokenUnvalidated extracts information from the given jwt token without validating it.
 // FederatedClaims are optional and
 // ResourceAccess are constructed from Roles and Groups claims.
-func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *security.Claims, error) {
+func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *auth.Claims, error) {
 
-	parsedClaims := &security.Claims{}
+	parsedClaims := &auth.Claims{}
 	webToken, err := jwt.ParseSigned(token)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing token: %s", err)
@@ -69,7 +70,7 @@ func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *security.Cl
 	user := &security.User{
 		Issuer:  parsedClaims.Issuer,
 		Subject: parsedClaims.Subject,
-		Name:    parsedClaims.Name,
+		Name:    parsedClaims.Username(),
 		EMail:   parsedClaims.EMail,
 		Groups:  res,
 		Tenant:  tenant,

--- a/jwt/sec/token_test.go
+++ b/jwt/sec/token_test.go
@@ -122,10 +122,12 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 				token: oldToken,
 			},
 			wantUser: &security.User{
-				EMail:  "achim.admin@tenant.de",
-				Name:   "achim",
-				Groups: grpsRA,
-				Tenant: "tnnt",
+				Issuer:  "https://dex.test.metal-stack.io/dex",
+				Subject: "achim",
+				EMail:   "achim.admin@tenant.de",
+				Name:    "achim",
+				Groups:  grpsRA,
+				Tenant:  "tnnt",
 			},
 			wantClaims: &security.Claims{
 				StandardClaims: jwt.StandardClaims{
@@ -154,10 +156,12 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 				token: newToken,
 			},
 			wantUser: &security.User{
-				EMail:  newTokenCfg.Email,
-				Name:   newTokenCfg.Name,
-				Groups: []security.ResourceAccess{security.ResourceAccess("Tn_k8s-all-all-cadm")},
-				Tenant: "",
+				Issuer:  newTokenCfg.IssuerUrl,
+				Subject: newTokenCfg.Subject,
+				EMail:   newTokenCfg.Email,
+				Name:    newTokenCfg.Name,
+				Groups:  []security.ResourceAccess{security.ResourceAccess("Tn_k8s-all-all-cadm")},
+				Tenant:  "",
 			},
 			wantClaims: &security.Claims{
 				StandardClaims: jwt.StandardClaims{

--- a/jwt/sec/token_test.go
+++ b/jwt/sec/token_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/go-cmp/cmp"
+	"github.com/metal-stack/metal-lib/auth"
 	libjwt "github.com/metal-stack/metal-lib/jwt/jwt"
 	"github.com/metal-stack/security"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,7 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 		name       string
 		args       args
 		wantUser   *security.User
-		wantClaims *security.Claims
+		wantClaims *auth.Claims
 		wantErr    bool
 	}{
 		{
@@ -129,24 +130,22 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 				Groups:  grpsRA,
 				Tenant:  "tnnt",
 			},
-			wantClaims: &security.Claims{
-				StandardClaims: jwt.StandardClaims{
-					Audience:  "",
-					ExpiresAt: expAtUnix,
-					Id:        "",
-					IssuedAt:  issAtUnix,
-					Issuer:    "https://dex.test.metal-stack.io/dex",
-					NotBefore: 0,
-					Subject:   "achim",
-				},
-				Audience: []interface{}{"theAudience"},
-				Groups:   []string{"tnnt_kaas-all-all-admin", "tnnt_maas-all-all-admin", "tnnt_k8s-test-all-clusteradmin", "tnnt_k8s-qa$poc-all-clusteradmin", "tnnt_k8s-ddd#ddd$poc-all-clusteradmin", "tnnt_k8s-prod$poc-all-clusteradmin"},
-				EMail:    "achim.admin@tenant.de",
-				Name:     "achim",
+			wantClaims: &auth.Claims{
+				ExpiresAt: expAtUnix,
+				Id:        "",
+				IssuedAt:  issAtUnix,
+				Issuer:    "https://dex.test.metal-stack.io/dex",
+				NotBefore: 0,
+				Subject:   "achim",
+				Audience:  []interface{}{string("theAudience")},
+				Groups:    []string{"tnnt_kaas-all-all-admin", "tnnt_maas-all-all-admin", "tnnt_k8s-test-all-clusteradmin", "tnnt_k8s-qa$poc-all-clusteradmin", "tnnt_k8s-ddd#ddd$poc-all-clusteradmin", "tnnt_k8s-prod$poc-all-clusteradmin"},
+				EMail:     "achim.admin@tenant.de",
+				Name:      "achim",
 				FederatedClaims: map[string]string{
 					"connector_id": "tnnt_ldap_openldap",
 					"user_id":      "cn=achim.admin,ou=People,dc=tenant,dc=de",
 				},
+				Roles: nil,
 			},
 			wantErr: false,
 		},
@@ -163,21 +162,18 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 				Groups:  []security.ResourceAccess{security.ResourceAccess("Tn_k8s-all-all-cadm")},
 				Tenant:  "",
 			},
-			wantClaims: &security.Claims{
-				StandardClaims: jwt.StandardClaims{
-					Audience:  "",
-					ExpiresAt: newTokenCfg.ExpiresAt.Unix(),
-					Id:        newTokenCfg.Id,
-					IssuedAt:  newTokenCfg.IssuedAt.Unix(),
-					Issuer:    newTokenCfg.IssuerUrl,
-					NotBefore: newTokenCfg.IssuedAt.Unix(),
-					Subject:   newTokenCfg.Subject,
-				},
-				Audience: []interface{}{newTokenCfg.Audience[0]},
-				Groups:   nil,
-				Roles:    []string{"Tn_k8s-all-all-cadm"},
-				EMail:    newTokenCfg.Email,
-				Name:     newTokenCfg.Name,
+			wantClaims: &auth.Claims{
+				ExpiresAt: newTokenCfg.ExpiresAt.Unix(),
+				Id:        newTokenCfg.Id,
+				IssuedAt:  newTokenCfg.IssuedAt.Unix(),
+				Issuer:    newTokenCfg.IssuerUrl,
+				NotBefore: newTokenCfg.IssuedAt.Unix(),
+				Subject:   newTokenCfg.Subject,
+				Audience:  []interface{}{newTokenCfg.Audience[0]},
+				Groups:    nil,
+				EMail:     newTokenCfg.Email,
+				Name:      newTokenCfg.Name,
+				Roles:     []string{"Tn_k8s-all-all-cadm"},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
* implement unvalidated parsing of token for "whoami" with all possible fields including Issuer & Subject
* prefer "perferred_username" over "name" if filled