### PR TITLE
migrate to golangci/golangci-lint-action@v2

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,9 +15,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Lint
-      uses: actions-contrib/golangci-lint@master
-      with:
-        args: run
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39.0
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:
-        go-version: '1.14.x'
+        go-version: '1.16.x'
     - name: Test
       run: |
         make

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,9 +15,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.39.0
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.39.0
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.39.0
+        args: -p bugs
     - name: Set up Go 1.14
       uses: actions/setup-go@v2
       with:

--- a/auth/templates.go
+++ b/auth/templates.go
@@ -5,7 +5,6 @@ import (
 	"html/template"
 	"log"
 	"net/http"
-	txttpl "text/template"
 )
 
 type tokenTmplData struct {
@@ -70,8 +69,8 @@ func renderTemplate(w http.ResponseWriter, tmpl *template.Template, data interfa
 		return
 	}
 
-	var execErr txttpl.ExecError
-	if errors.As(err, &execErr) {
+	var templateErr *template.Error
+	if errors.As(err, &templateErr) {
 		// An ExecError guarantees that Execute has not written to the underlying reader.
 		log.Printf("Error rendering template %s: %s", tmpl.Name(), err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/auth/templates.go
+++ b/auth/templates.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"errors"
 	"html/template"
 	"log"
 	"net/http"
+	txttpl "text/template"
 )
 
 type tokenTmplData struct {
@@ -68,14 +70,12 @@ func renderTemplate(w http.ResponseWriter, tmpl *template.Template, data interfa
 		return
 	}
 
-	switch err := err.(type) {
-	case *template.Error:
+	var execErr txttpl.ExecError
+	if errors.As(err, &execErr) {
 		// An ExecError guarantees that Execute has not written to the underlying reader.
 		log.Printf("Error rendering template %s: %s", tmpl.Name(), err)
-
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
-	default:
-		// An error with the underlying write, such as the connection being
-		// dropped. Ignore for now.
+	} else {
+		log.Printf("Error rendering template %s: %s", tmpl.Name(), err)
 	}
 }

--- a/bus/eventbus.go
+++ b/bus/eventbus.go
@@ -141,7 +141,7 @@ func (c *Consumer) MustRegister(topic, channel string) *ConsumerRegistration {
 func (c *Consumer) Register(topic, channel string) (*ConsumerRegistration, error) {
 	q, err := nsq.NewConsumer(topic, channel, c.config)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create consumer for topic:%q, channel:%q: %v", topic, channel, err)
+		return nil, fmt.Errorf("cannot create consumer for topic:%q, channel:%q: %w", topic, channel, err)
 	}
 
 	cr := &ConsumerRegistration{
@@ -331,7 +331,7 @@ func NewPublisher(zlog *zap.Logger, publisherCfg *PublisherConfig) (Publisher, e
 	publisherCfg.ConfigureNSQ()
 	p, err := nsq.NewProducer(publisherCfg.TCPAddress, publisherCfg.NSQ)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create producer with nsqd=%q: %v", publisherCfg.TCPAddress, err)
+		return nil, fmt.Errorf("cannot create producer with nsqd=%q: %w", publisherCfg.TCPAddress, err)
 	}
 	pbl := &nsqPublisher{
 		log:          zlog,
@@ -348,7 +348,7 @@ func NewPublisher(zlog *zap.Logger, publisherCfg *PublisherConfig) (Publisher, e
 func (p *nsqPublisher) Publish(topic string, data interface{}) error {
 	b, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("cannot marshal data to json: %v", err)
+		return fmt.Errorf("cannot marshal data to json: %w", err)
 	}
 	return p.producer.Publish(topic, b)
 }
@@ -356,6 +356,7 @@ func (p *nsqPublisher) Publish(topic string, data interface{}) error {
 // CreateTopic needs to be called with an HTTP request since the library does not support creating
 // topics (they are created implicitly)
 func (p *nsqPublisher) CreateTopic(topic string) error {
+	//nolint:noctx
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/topic/create?topic=%s", p.httpEndpoint, topic), nil)
 	if err != nil {
 		return err

--- a/bus/eventbus_test.go
+++ b/bus/eventbus_test.go
@@ -1,6 +1,7 @@
 package bus
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -184,7 +185,8 @@ func TestNewPublisher(t *testing.T) {
 
 	err := publisher.CreateTopic("topic42")
 
-	if _, ok := err.(net.Error); ok {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
 		// network error, no nsq running, skip roundtrip tests
 		t.SkipNow()
 	}
@@ -338,6 +340,7 @@ func TestBridgeNsqLogToCoreLog(t *testing.T) {
 	}
 
 	for _, tst := range tests {
+		tst := tst
 		t.Run(tst.Level.String(), func(t *testing.T) {
 			// record all messages of all levels
 			core, recorded := observer.New(zapcore.DebugLevel)

--- a/httperrors/error.go
+++ b/httperrors/error.go
@@ -134,5 +134,6 @@ func UnknownError(err error) *HTTPErrorResponse {
 
 // UnconventionalError creates a new error with a given error message for a response that did not follow the internal error convention. Convenience Method.
 func UnconventionalError(err error) *HTTPErrorResponse {
-	return NewHTTPError(http.StatusInternalServerError, fmt.Errorf("unexpected error: client response does not follow internal error convention: %v", err.Error()))
+	//nolint:errorlint
+	return NewHTTPError(http.StatusInternalServerError, fmt.Errorf("unexpected error: client response does not follow internal error convention: %s", err.Error()))
 }

--- a/httperrors/error_test.go
+++ b/httperrors/error_test.go
@@ -34,6 +34,7 @@ func TestHTTPErrorResponse_UnmarshalText(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			h := &HTTPErrorResponse{}
 			err := h.UnmarshalText(tt.text)

--- a/jwt/grp/connector_test.go
+++ b/jwt/grp/connector_test.go
@@ -80,6 +80,7 @@ func TestParseConnectorId(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotJwtTenant, gotDirectory, err := ParseConnectorId(tt.args.connectorId)
 			if (err != nil) != tt.wantErr {

--- a/jwt/grp/groupcontext_test.go
+++ b/jwt/grp/groupcontext_test.go
@@ -56,7 +56,7 @@ var invalidGroupTests = []ExpectedErrorTest{
 
 func TestParsegroupInvalid(t *testing.T) {
 	for _, test := range invalidGroupTests {
-
+		test := test
 		t.Run(test.groupString, func(t *testing.T) {
 
 			_, err := grpr.ParseGroupName(test.groupString)
@@ -133,7 +133,7 @@ var validGroupTests = []ExpectedGroupTest{
 
 func TestParseGroupValid(t *testing.T) {
 	for _, test := range validGroupTests {
-
+		test := test
 		t.Run(test.groupString, func(t *testing.T) {
 			result, err := grpr.ParseGroupName(test.groupString)
 
@@ -350,11 +350,9 @@ func TestParseUXValid(t *testing.T) {
 
 func runGroupContextExpectedErrorTests(t *testing.T, tests []ExpectedErrorTest, parseFn GroupContextParseFunc) {
 	for _, test := range tests {
-
+		test := test
 		t.Run(test.groupString, func(t *testing.T) {
-
 			_, err := parseFn(test.groupString)
-
 			require.Error(t, err, test.groupString)
 			require.Equal(t, test.expectedError, err, test.groupString)
 		})
@@ -363,10 +361,9 @@ func runGroupContextExpectedErrorTests(t *testing.T, tests []ExpectedErrorTest, 
 
 func runGroupContextExpectedResultTests(t *testing.T, tests []ExpectedGroupContextTest, parseFn GroupContextParseFunc) {
 	for _, test := range tests {
-
+		test := test
 		t.Run(test.groupString, func(t *testing.T) {
 			result, err := parseFn(test.groupString)
-
 			require.NoError(t, err, test.groupString)
 			require.Equal(t, test.result, result, test.groupString)
 			require.Equal(t, test.prefixedGroupString, result.ToPrefixedGroupString("oidc:"))
@@ -401,6 +398,7 @@ func TestGroupEncodeName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := grpr.GroupEncodeName(tt.args.name); got != tt.want {
 				t.Errorf("GroupEncodeName() = %v, want %v", got, tt.want)
@@ -425,6 +423,7 @@ func TestGroupEncodeNames(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := grpr.GroupEncodeNames(tt.args.names); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GroupEncodeNames() = %v, want %v", got, tt.want)
@@ -456,6 +455,7 @@ func TestFromStringToFullGroupStringRoundtrip(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := grpr.ParseGroupName(tt.name)
 			if (err != nil) != tt.wantErr {
@@ -499,6 +499,7 @@ func TestGroup_ToOnBehalfGroupString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := &Group{
 				AppPrefix:      tt.fields.AppPrefix,

--- a/jwt/grp/groupexpression_test.go
+++ b/jwt/grp/groupexpression_test.go
@@ -312,6 +312,7 @@ func TestGroupExpression_Matches(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := tt.fields.groupExpr
 			if got := g.Matches(tt.args.group); got != tt.want {

--- a/jwt/grp/types_test.go
+++ b/jwt/grp/types_test.go
@@ -57,8 +57,10 @@ func TestNewGroup(t *testing.T) {
 	grpr := MustNewGrpr(Config{ProviderTenant: "tnnt"})
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := grpr.NewGroup(tt.args.app, tt.args.onBehalfTenant, tt.args.firstScope, tt.args.secondScope, tt.args.role); !reflect.DeepEqual(got, tt.want) {
+				//nolint:errorlint
 				t.Errorf("NewGroup() = %v, want %v", got, tt.want)
 			}
 		})

--- a/jwt/sec/plugin_test.go
+++ b/jwt/sec/plugin_test.go
@@ -149,8 +149,8 @@ func TestExtractUserProcessGroups(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			plg := plugin
 			if tt.args.plugin != nil {
 				plg = tt.args.plugin
@@ -370,8 +370,8 @@ func TestGenericOIDCExtractUserProcessGroups(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			plg := plugin
 			if tt.args.plugin != nil {
 				plg = tt.args.plugin
@@ -771,7 +771,9 @@ func TestHasGroupExpression(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		for _, exp := range tt.args.expression {
+			exp := exp
 			t.Run(fmt.Sprintf("%s:%v", tt.name, exp.expr), func(t *testing.T) {
 				if got := plugin.HasGroupExpression(tt.args.user, tt.args.resourceTenant, exp.expr); got != exp.want {
 					t.Errorf("HasGroupExpression(%v) = %v, want %v", exp.expr, got, exp.want)
@@ -828,6 +830,7 @@ func TestMergeResourceAccess(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MergeResourceAccess(tt.args.ras...); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MergeResourceAccess() = %v, want %v", got, tt.want)
@@ -994,6 +997,7 @@ func TestTenantsOnBehalf(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotTenants, gotAll, err := plugin.TenantsOnBehalf(tt.args.user, tt.args.groups)
 			if (err != nil) != tt.wantErr {

--- a/jwt/sec/token.go
+++ b/jwt/sec/token.go
@@ -14,17 +14,17 @@ func (p *Plugin) ParseTokenUnvalidated(token string) (*security.User, *security.
 	parsedClaims := &security.Claims{}
 	webToken, err := jwt.ParseSigned(token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing token: %s", err)
+		return nil, nil, fmt.Errorf("error parsing token: %w", err)
 	}
 
 	err = webToken.UnsafeClaimsWithoutVerification(parsedClaims)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing token claims: %s", err)
+		return nil, nil, fmt.Errorf("error parsing token claims: %w", err)
 	}
 
 	user, err := p.ExtractUserProcessGroups(parsedClaims)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error extracting user: %s", err)
+		return nil, nil, fmt.Errorf("error extracting user: %w", err)
 	}
 
 	return user, parsedClaims, nil
@@ -38,12 +38,12 @@ func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *auth.Claims
 	parsedClaims := &auth.Claims{}
 	webToken, err := jwt.ParseSigned(token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing token: %s", err)
+		return nil, nil, fmt.Errorf("error parsing token: %w", err)
 	}
 
 	err = webToken.UnsafeClaimsWithoutVerification(parsedClaims)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing token claims: %s", err)
+		return nil, nil, fmt.Errorf("error parsing token claims: %w", err)
 	}
 
 	// check federated claims
@@ -77,7 +77,7 @@ func ParseTokenUnvalidatedUnfiltered(token string) (*security.User, *auth.Claims
 	}
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("error extracting user: %s", err)
+		return nil, nil, fmt.Errorf("error extracting user: %w", err)
 	}
 
 	return user, parsedClaims, nil

--- a/jwt/sec/token_test.go
+++ b/jwt/sec/token_test.go
@@ -70,6 +70,7 @@ func TestParseTokenUnvalidated(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1, err := plugin.ParseTokenUnvalidated(tt.args.token)
 			if (err != nil) != tt.wantErr {
@@ -214,9 +215,11 @@ func TestParseTokenUnvalidatedUnfiltered(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotUser, gotClaims, err := ParseTokenUnvalidatedUnfiltered(tt.args.token)
 			if (err != nil) != tt.wantErr {
+				//nolint:errorlint
 				t.Errorf("ParseTokenUnvalidatedUnfiltered() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/pkg/sign/sign_test.go
+++ b/pkg/sign/sign_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSignAndVerify(t *testing.T) {
 	// Generate new KeyPair
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(err)
 	}
@@ -74,6 +74,7 @@ func TestSignAndVerify(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			signature, err := Sign(tt.args.privateKey, tt.args.dataSigning)
 			if err != nil {

--- a/rest/health_test.go
+++ b/rest/health_test.go
@@ -39,6 +39,7 @@ func TestNewHealth(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ws := NewHealth(tt.args.log, tt.args.basePath, tt.args.h...)
 
@@ -49,6 +50,7 @@ func TestNewHealth(t *testing.T) {
 			container.ServeHTTP(w, createReq)
 
 			resp := w.Result()
+			defer resp.Body.Close()
 			var s status
 			err = json.NewDecoder(resp.Body).Decode(&s)
 			require.NoError(t, err)

--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -94,7 +95,8 @@ func UserAuth(ug security.UserGetter) restful.FilterFunction {
 		log := zapup.RequestLogger(req.Request)
 		usr, err := ug.User(req.Request)
 		if err != nil {
-			if hmerr, ok := err.(*security.WrongHMAC); ok {
+			var hmerr *security.WrongHMAC
+			if errors.As(err, &hmerr) {
 				log.Error("cannot get user from request", zap.Error(err), zap.String("got", hmerr.Got), zap.String("want", hmerr.Want))
 			} else {
 				log.Error("cannot get user from request", zap.Error(err))


### PR DESCRIPTION
Fix: Unable to resolve action `actions-contrib/golangci-lint@master`, repository not found