### PR TITLE
Add default returns for rest endpoints.

### DIFF
--- a/rest/health.go
+++ b/rest/health.go
@@ -5,6 +5,7 @@ import (
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	restful "github.com/emicklei/go-restful/v3"
+	"github.com/metal-stack/metal-lib/httperrors"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +52,8 @@ func NewHealth(log *zap.Logger, basePath string, h ...HealthCheck) *restful.WebS
 		Doc("perform a healthcheck").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "OK", status{}).
-		Returns(http.StatusInternalServerError, "Unhealthy", status{}))
+		Returns(http.StatusInternalServerError, "Unhealthy", status{}).
+		DefaultReturns("Error", httperrors.HTTPErrorResponse{}))
 	return ws
 }
 

--- a/rest/version.go
+++ b/rest/version.go
@@ -5,6 +5,7 @@ import (
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	restful "github.com/emicklei/go-restful/v3"
+	"github.com/metal-stack/metal-lib/httperrors"
 	"github.com/metal-stack/v"
 )
 
@@ -43,7 +44,8 @@ func NewVersion(name string, basePath string) *restful.WebService {
 			Operation("info").
 			To(func(r *restful.Request, rsp *restful.Response) {
 				_ = rsp.WriteAsJson(vi)
-			}))
+			}).
+			DefaultReturns("Error", httperrors.HTTPErrorResponse{}))
 
 	return ws
 }


### PR DESCRIPTION
Otherwise the errors cannot be translated properly through the swagger clients.