### PR TITLE
Do table padding with whitespaces instead of tabs.

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -574,11 +574,14 @@ func newRandomPortListener() (net.Listener, string, error) {
 }
 
 func fetchJSON(url string, data any) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}

--- a/auth/kubeconfig.go
+++ b/auth/kubeconfig.go
@@ -324,8 +324,7 @@ type AuthContext struct {
 }
 
 // finds the listKey from the given map, gets the list of maps, finds the map with matchKey == matchValue, returns map, index, error
-func findMapListMap(cfg map[interface{}]interface{}, listKey string, matchKey string, matchValue string) (map[string]interface{}, int, error) {
-
+func findMapListMap(cfg map[interface{}]interface{}, listKey string, matchKey string, matchValue string) (map[string]interface{}, int, error) { //nolint:unparam
 	ctxSlice, err := dyno.GetSlice(cfg, listKey)
 	if err != nil {
 		return nil, 0, err

--- a/bus/bus_test.go
+++ b/bus/bus_test.go
@@ -15,7 +15,7 @@ var (
 	consumer    *Consumer
 )
 
-func startupNSQD() error {
+func startupNSQD() {
 	_, disable := os.LookupEnv("NO_NSQD_START")
 	if !disable {
 		opts := nsqd.NewOptions()
@@ -49,12 +49,10 @@ func startupNSQD() error {
 	if err != nil {
 		panic(err)
 	}
-
-	return nil
 }
 
 func TestMain(m *testing.M) {
-	_ = startupNSQD()
+	startupNSQD()
 	code := m.Run()
 	os.Exit(code)
 }

--- a/pkg/genericcli/printers.go
+++ b/pkg/genericcli/printers.go
@@ -250,7 +250,7 @@ func NewTablePrinter(config *TablePrinterConfig) (*TablePrinter, error) {
 		table.SetColumnSeparator("")
 		table.SetRowSeparator("")
 		table.SetRowLine(false)
-		table.SetTablePadding("\t") // pad with tabs
+		table.SetTablePadding("  ")
 		table.SetNoWhiteSpace(true) // no whitespace in front of every line
 	}
 


### PR DESCRIPTION
This reduces the width of a lot of commands significantly.