### PR TITLE
Print apply results immediately by default.

### DIFF
--- a/pkg/genericcli/cmds.go
+++ b/pkg/genericcli/cmds.go
@@ -99,12 +99,7 @@ func NewCmds[C any, U any, R any](c *CmdsConfig[C, U, R], additionalCmds ...*cob
 			Aliases: []string{"get"},
 			Short:   fmt.Sprintf("describes the %s", c.Singular),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				id, err := GetExactlyOneArg(args)
-				if err != nil {
-					return err
-				}
-
-				return c.GenericCLI.DescribeAndPrint(id, c.DescribePrinter())
+				return c.GenericCLI.DescribeAndPrint(args, c.DescribePrinter())
 			},
 			ValidArgsFunction: c.ValidArgsFn,
 		}
@@ -177,12 +172,7 @@ func NewCmds[C any, U any, R any](c *CmdsConfig[C, U, R], additionalCmds ...*cob
 			Short:   fmt.Sprintf("deletes the %s", c.Singular),
 			Aliases: []string{"destroy", "rm", "remove"},
 			RunE: func(cmd *cobra.Command, args []string) error {
-				id, err := GetExactlyOneArg(args)
-				if err != nil {
-					return err
-				}
-
-				return c.GenericCLI.DeleteAndPrint(id, c.DescribePrinter())
+				return c.GenericCLI.DeleteAndPrint(args, c.DescribePrinter())
 			},
 			ValidArgsFunction: c.ValidArgsFn,
 		}

--- a/pkg/genericcli/cmds.go
+++ b/pkg/genericcli/cmds.go
@@ -189,12 +189,16 @@ func NewCmds[C any, U any, R any](c *CmdsConfig[C, U, R], additionalCmds ...*cob
 			Use:   "apply",
 			Short: fmt.Sprintf("applies one or more %s from a given file", c.Plural),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if viper.GetBool("bulk-output") {
+					c.GenericCLI = c.GenericCLI.WithApplyBulkPrint()
+				}
 				return c.GenericCLI.ApplyFromFileAndPrint(viper.GetString("file"), c.ListPrinter())
 			},
 		}
 
 		cmd.Flags().StringP("file", "f", "", c.fileFlagHelpText("apply"))
 		Must(cmd.MarkFlagRequired("file"))
+		cmd.Flags().Bool("bulk-output", false, `prints apply results in a bulk at the end, the results are a list. default is printing results intermediately during apply, which causes single entities to be printed sequentially.`)
 
 		if c.ApplyCmdMutateFn != nil {
 			c.ApplyCmdMutateFn(cmd)

--- a/pkg/genericcli/cmds.go
+++ b/pkg/genericcli/cmds.go
@@ -99,7 +99,12 @@ func NewCmds[C any, U any, R any](c *CmdsConfig[C, U, R], additionalCmds ...*cob
 			Aliases: []string{"get"},
 			Short:   fmt.Sprintf("describes the %s", c.Singular),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return c.GenericCLI.DescribeAndPrint(args, c.DescribePrinter())
+				id, err := GetExactlyOneArg(args)
+				if err != nil {
+					return err
+				}
+
+				return c.GenericCLI.DescribeAndPrint(id, c.DescribePrinter())
 			},
 			ValidArgsFunction: c.ValidArgsFn,
 		}
@@ -172,7 +177,12 @@ func NewCmds[C any, U any, R any](c *CmdsConfig[C, U, R], additionalCmds ...*cob
 			Short:   fmt.Sprintf("deletes the %s", c.Singular),
 			Aliases: []string{"destroy", "rm", "remove"},
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return c.GenericCLI.DeleteAndPrint(args, c.DescribePrinter())
+				id, err := GetExactlyOneArg(args)
+				if err != nil {
+					return err
+				}
+
+				return c.GenericCLI.DeleteAndPrint(id, c.DescribePrinter())
 			},
 			ValidArgsFunction: c.ValidArgsFn,
 		}

--- a/pkg/genericcli/crud.go
+++ b/pkg/genericcli/crud.go
@@ -42,13 +42,8 @@ func (a *GenericCLI[C, U, R]) ListAndPrint(p printers.Printer, sortKeys ...multi
 	return p.Print(resp)
 }
 
-func (a *GenericCLI[C, U, R]) Describe(args []string) (R, error) {
+func (a *GenericCLI[C, U, R]) Describe(id string) (R, error) {
 	var zero R
-
-	id, err := GetExactlyOneArg(args)
-	if err != nil {
-		return zero, err
-	}
 
 	resp, err := a.crud.Get(id)
 	if err != nil {
@@ -58,8 +53,8 @@ func (a *GenericCLI[C, U, R]) Describe(args []string) (R, error) {
 	return resp, nil
 }
 
-func (a *GenericCLI[C, U, R]) DescribeAndPrint(args []string, p printers.Printer) error {
-	resp, err := a.Describe(args)
+func (a *GenericCLI[C, U, R]) DescribeAndPrint(id string, p printers.Printer) error {
+	resp, err := a.Describe(id)
 	if err != nil {
 		return err
 	}
@@ -67,13 +62,8 @@ func (a *GenericCLI[C, U, R]) DescribeAndPrint(args []string, p printers.Printer
 	return p.Print(resp)
 }
 
-func (a *GenericCLI[C, U, R]) Delete(args []string) (R, error) {
+func (a *GenericCLI[C, U, R]) Delete(id string) (R, error) {
 	var zero R
-
-	id, err := GetExactlyOneArg(args)
-	if err != nil {
-		return zero, err
-	}
 
 	resp, err := a.crud.Delete(id)
 	if err != nil {
@@ -83,8 +73,8 @@ func (a *GenericCLI[C, U, R]) Delete(args []string) (R, error) {
 	return resp, nil
 }
 
-func (a *GenericCLI[C, U, R]) DeleteAndPrint(args []string, p printers.Printer) error {
-	resp, err := a.Delete(args)
+func (a *GenericCLI[C, U, R]) DeleteAndPrint(id string, p printers.Printer) error {
+	resp, err := a.Delete(id)
 	if err != nil {
 		return err
 	}

--- a/pkg/genericcli/crud.go
+++ b/pkg/genericcli/crud.go
@@ -42,8 +42,13 @@ func (a *GenericCLI[C, U, R]) ListAndPrint(p printers.Printer, sortKeys ...multi
 	return p.Print(resp)
 }
 
-func (a *GenericCLI[C, U, R]) Describe(id string) (R, error) {
+func (a *GenericCLI[C, U, R]) Describe(args []string) (R, error) {
 	var zero R
+
+	id, err := GetExactlyOneArg(args)
+	if err != nil {
+		return zero, err
+	}
 
 	resp, err := a.crud.Get(id)
 	if err != nil {
@@ -53,8 +58,8 @@ func (a *GenericCLI[C, U, R]) Describe(id string) (R, error) {
 	return resp, nil
 }
 
-func (a *GenericCLI[C, U, R]) DescribeAndPrint(id string, p printers.Printer) error {
-	resp, err := a.Describe(id)
+func (a *GenericCLI[C, U, R]) DescribeAndPrint(args []string, p printers.Printer) error {
+	resp, err := a.Describe(args)
 	if err != nil {
 		return err
 	}
@@ -62,8 +67,13 @@ func (a *GenericCLI[C, U, R]) DescribeAndPrint(id string, p printers.Printer) er
 	return p.Print(resp)
 }
 
-func (a *GenericCLI[C, U, R]) Delete(id string) (R, error) {
+func (a *GenericCLI[C, U, R]) Delete(args []string) (R, error) {
 	var zero R
+
+	id, err := GetExactlyOneArg(args)
+	if err != nil {
+		return zero, err
+	}
 
 	resp, err := a.crud.Delete(id)
 	if err != nil {
@@ -73,8 +83,8 @@ func (a *GenericCLI[C, U, R]) Delete(id string) (R, error) {
 	return resp, nil
 }
 
-func (a *GenericCLI[C, U, R]) DeleteAndPrint(id string, p printers.Printer) error {
-	resp, err := a.Delete(id)
+func (a *GenericCLI[C, U, R]) DeleteAndPrint(args []string, p printers.Printer) error {
+	resp, err := a.Delete(args)
 	if err != nil {
 		return err
 	}

--- a/pkg/genericcli/fromfile.go
+++ b/pkg/genericcli/fromfile.go
@@ -74,7 +74,7 @@ func (ms MultiApplyResults[R]) ToList() []R {
 	return result
 }
 
-func (ms MultiApplyResults[R]) Error() error {
+func (ms MultiApplyResults[R]) Error(joinErrors bool) error {
 	var errors []string
 
 	for _, m := range ms {
@@ -87,7 +87,11 @@ func (ms MultiApplyResults[R]) Error() error {
 		return nil
 	}
 
-	return fmt.Errorf("errors occurred during apply: %s", strings.Join(errors, ", "))
+	if joinErrors {
+		return fmt.Errorf("errors occurred during apply: %s", strings.Join(errors, ", "))
+	}
+
+	return fmt.Errorf("errors occurred during apply")
 }
 
 func AlreadyExistsError() error {
@@ -215,7 +219,12 @@ func (a *GenericCLI[C, U, R]) ApplyFromFile(from string, p printers.Printer) (Mu
 		results = res.Append(results, MultiApplyErrorOnUpdate, nil, fmt.Errorf("error updating entity: %w", err))
 	}
 
-	return results, results.Error()
+	joinErrors := false
+	if p == nil {
+		joinErrors = true
+	}
+
+	return results, results.Error(joinErrors)
 }
 
 func (a *GenericCLI[C, U, R]) ApplyFromFileAndPrint(from string, p printers.Printer) error {

--- a/pkg/genericcli/fromfile_test.go
+++ b/pkg/genericcli/fromfile_test.go
@@ -162,7 +162,7 @@ name: two
 					},
 				},
 			},
-			wantErr: fmt.Errorf("errors occurred during apply: error creating entity: creation error for id 1"),
+			wantErr: fmt.Errorf("errors occurred during apply"),
 			wantOutput: `
 error creating entity: creation error for id 1
 | ID | NAME |

--- a/pkg/genericcli/generic.go
+++ b/pkg/genericcli/generic.go
@@ -15,6 +15,8 @@ type GenericCLI[C any, U any, R any] struct {
 	crud   CRUD[C, U, R]
 	parser MultiDocumentYAML[R]
 	sorter *multisort.Sorter[R]
+
+	intermediateApplyPrint bool
 }
 
 // CRUD must be implemented in order to get generic CLI functionality.
@@ -49,9 +51,10 @@ type CRUD[C any, U any, R any] interface {
 func NewGenericCLI[C any, U any, R any](crud CRUD[C, U, R]) *GenericCLI[C, U, R] {
 	fs := afero.NewOsFs()
 	return &GenericCLI[C, U, R]{
-		crud:   crud,
-		fs:     fs,
-		parser: MultiDocumentYAML[R]{fs: fs},
+		crud:                   crud,
+		fs:                     fs,
+		parser:                 MultiDocumentYAML[R]{fs: fs},
+		intermediateApplyPrint: true,
 	}
 }
 
@@ -63,6 +66,13 @@ func (a *GenericCLI[C, U, R]) WithFS(fs afero.Fs) *GenericCLI[C, U, R] {
 
 func (a *GenericCLI[C, U, R]) WithSorter(sorter *multisort.Sorter[R]) *GenericCLI[C, U, R] {
 	a.sorter = sorter
+	return a
+}
+
+// WithApplyBulkPrint prints apply results in a bulk at the end, the results are a list.
+// default is printing results intermediately during apply, which causes single entities to be printed sequentially.
+func (a *GenericCLI[C, U, R]) WithApplyBulkPrint() *GenericCLI[C, U, R] {
+	a.intermediateApplyPrint = false
 	return a
 }
 

--- a/pkg/genericcli/printers/table.go
+++ b/pkg/genericcli/printers/table.go
@@ -29,6 +29,8 @@ type TablePrinterConfig struct {
 	Out io.Writer
 	// CustomPadding defines the table padding, defaults to three whitespaces
 	CustomPadding *string
+	// DisableDefaultErrorPrinter disables the default error printer when the given print data is of type error.
+	DisableDefaultErrorPrinter bool
 }
 
 func NewTablePrinter(config *TablePrinterConfig) *TablePrinter {
@@ -55,6 +57,11 @@ func (p *TablePrinter) MutateTable(mutateFn func(table *tablewriter.Table)) {
 }
 
 func (p *TablePrinter) Print(data any) error {
+	if err, ok := data.(error); ok && !p.c.DisableDefaultErrorPrinter {
+		fmt.Fprintf(p.c.Out, "%s\n", err)
+		return nil
+	}
+
 	if err := p.initTable(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #61.

Defaults to printing results intermediately during apply, which causes single entities to be printed sequentially. Can be disabled by the generic CLI configuration to maintain old behavior (printing apply result as a bulk in the end, printed entity is a list of objects).