### PR TITLE
expose request id in context

### DIFF
--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -18,7 +18,8 @@ import (
 type Key int
 
 const (
-	RequestLoggerKey = Key(0)
+	RequestLoggerKey Key = iota
+	RequestIDKey
 )
 
 type loggingResponseWriter struct {
@@ -77,6 +78,7 @@ func RequestLoggerFilter(logger *zap.SugaredLogger) restful.FilterFunction {
 		requestLogger := logger.With(fields...)
 
 		enrichedContext := context.WithValue(req.Request.Context(), RequestLoggerKey, requestLogger)
+		enrichedContext = context.WithValue(enrichedContext, RequestIDKey, requestID)
 		req.Request = req.Request.WithContext(enrichedContext)
 
 		t := time.Now()


### PR DESCRIPTION
Implements auditing with Meilisearch https://github.com/metal-stack-cloud/docs/issues/33.
More details can be found in [MEP11](https://docs.metal-stack.io/stable/development/proposals/MEP11/README/).
Does not implement the sidecar for the s3 sync.

Consists of multiple PRs:

- https://github.com/metal-stack/helm-charts/pull/53
- https://github.com/metal-stack/mini-lab/pull/132
- https://github.com/metal-stack/metal-api/pull/372
- https://github.com/metal-stack/metal-roles/pull/113
- https://github.com/metal-stack/metal-lib/pull/66

1. Clone all of these and check out `feature/auditing` to get started testing.
2. in `mini-lab/docker-compose.yaml` add volumes to `control-plane` and `partition`.

```yaml
      # adjust the paths to your actual repo locations
      - ${HOME}/dev/ms/helm-charts:/helm-charts:ro
      - ${HOME}/dev/ms/metal-roles:/root/.ansible/roles/metal-roles:ro
```

3. in `mini-lab/inventories/group_vars/control-plane/metal.yml` uncomment `metal_helm_chart_local_path: /helm-charts/charts/metal-control-plane`
4. in mini-lab, run `make up` and wait
5. in metal-api, run `make mini-lab-push` and wait
6. Run `kubectl get pods -n metal-control-plane --watch` and wait for all pods to be running or completed
7. in mini-lab run `make firewall`
8. in mini-lab run `make machine`
9. open http://mtl-auditing.172.17.0.1.nip.io:8080/ and enter the secret from mini-lab (default `metal_auditing_secret: "secret"`)
10. You should see some logs from GRPC and Rest calls

If a request fails, copy the rqid from your logs and paste them in qoutes into meilisearch. You should now see exactly two results!