### PR TITLE
Migrate auditing from metal-api and api-server

### DIFF
--- a/auditing/auditing-interceptor.go
+++ b/auditing/auditing-interceptor.go
@@ -1,0 +1,210 @@
+package auditing
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/google/uuid"
+	"github.com/metal-stack/metal-lib/rest"
+	"github.com/metal-stack/security"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+const (
+	Exclude string = "exclude-from-auditing"
+)
+
+func UnaryServerInterceptor(a Auditing, logger *zap.SugaredLogger, shouldAudit func(fullMethod string) bool) grpc.UnaryServerInterceptor {
+	if a == nil {
+		logger.Fatal("cannot use nil auditing to create unary server interceptor")
+	}
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		if !shouldAudit(info.FullMethod) {
+			return handler(ctx, req)
+		}
+		requestID := uuid.New().String()
+		childCtx := context.WithValue(ctx, rest.RequestIDKey, requestID)
+
+		auditReqContext := []any{
+			"rqid", requestID,
+			"method", info.FullMethod,
+			"kind", "grpc",
+		}
+		user := security.GetUserFromContext(ctx)
+		if user != nil {
+			auditReqContext = append(
+				auditReqContext,
+				"user", user.EMail,
+				"tenant", user.Tenant,
+			)
+		}
+		err = a.Index(auditReqContext...)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = handler(childCtx, req)
+		if err != nil {
+			auditRespContext := append(auditReqContext, "err", err)
+			err2 := a.Index(auditRespContext...)
+			if err2 != nil {
+				logger.Errorf("unable to index error: %v", err2)
+			}
+			return nil, err
+		}
+		auditRespContext := append(auditReqContext, "resp", resp)
+		err = a.Index(auditRespContext...)
+		return resp, err
+	}
+}
+
+func StreamServerInterceptor(a Auditing, logger *zap.SugaredLogger, shouldAudit func(fullMethod string) bool) grpc.StreamServerInterceptor {
+	if a == nil {
+		logger.Fatal("cannot use nil auditing to create stream server interceptor")
+	}
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !shouldAudit(info.FullMethod) {
+			return handler(srv, ss)
+		}
+		requestID := uuid.New().String()
+		auditReqContext := []any{
+			"rqid", requestID,
+			"method", info.FullMethod,
+			"kind", "grpc-stream",
+		}
+
+		user := security.GetUserFromContext(ss.Context())
+		if user != nil {
+			auditReqContext = append(
+				auditReqContext,
+				"user", user.EMail,
+				"tenant", user.Tenant,
+			)
+		}
+		err := a.Index(auditReqContext...)
+		if err != nil {
+			return err
+		}
+		err = handler(srv, ss)
+		if err != nil {
+			auditRespContext := append(auditReqContext, "err", err)
+			err2 := a.Index(auditRespContext...)
+			if err2 != nil {
+				logger.Errorf("unable to index error: %v", err2)
+			}
+			return err
+		}
+		auditRespContext := append(auditReqContext, "finished", true)
+		err = a.Index(auditRespContext...)
+		return err
+	}
+}
+
+func HttpFilter(a Auditing, logger *zap.SugaredLogger) restful.FilterFunction {
+	if a == nil {
+		logger.Fatal("cannot use nil auditing to create http middleware")
+	}
+	return func(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+		r := request.Request
+
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+			break
+		default:
+			chain.ProcessFilter(request, response)
+			return
+		}
+
+		excluded, ok := request.SelectedRoute().Metadata()[Exclude].(bool)
+		if ok && excluded {
+			logger.Debugw("excluded route from auditing through metadata annotation", "path", request.SelectedRoute().Path())
+			chain.ProcessFilter(request, response)
+			return
+		}
+
+		requestID := r.Context().Value(rest.RequestIDKey)
+		if requestID == nil {
+			requestID = uuid.New().String()
+		}
+		auditReqContext := []any{
+			"rqid", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"forwarded-for", request.HeaderParameter("x-forwarded-for"),
+			"remote-addr", r.RemoteAddr,
+		}
+		user := security.GetUserFromContext(r.Context())
+		if user != nil {
+			auditReqContext = append(
+				auditReqContext,
+				"user", user.EMail,
+				"tenant", user.Tenant,
+			)
+		}
+
+		if r.Method != http.MethodGet && r.Body != nil {
+			bodyReader := r.Body
+			body, err := io.ReadAll(bodyReader)
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			if err != nil {
+				logger.Errorf("unable to read request body: %v", err)
+				response.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			auditReqContext = append(auditReqContext, "body", string(body))
+		}
+
+		err := a.Index(auditReqContext...)
+		if err != nil {
+			logger.Errorf("unable to index error: %v", err)
+			response.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		bufferedResponseWriter := &bufferedHttpResponseWriter{
+			w: response.ResponseWriter,
+		}
+		response.ResponseWriter = bufferedResponseWriter
+
+		chain.ProcessFilter(request, response)
+
+		auditRespContext := append(auditReqContext,
+			"resp", bufferedResponseWriter.Content(),
+			"status-code", response.StatusCode(),
+		)
+		err = a.Index(auditRespContext...)
+		if err != nil {
+			logger.Errorf("unable to index error: %v", err)
+			response.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+type bufferedHttpResponseWriter struct {
+	w http.ResponseWriter
+
+	buf    bytes.Buffer
+	header int
+}
+
+func (w *bufferedHttpResponseWriter) Header() http.Header {
+	return w.w.Header()
+}
+
+func (w *bufferedHttpResponseWriter) Write(b []byte) (int, error) {
+	(&w.buf).Write(b)
+	return w.w.Write(b)
+}
+
+func (w *bufferedHttpResponseWriter) WriteHeader(h int) {
+	w.header = h
+	w.w.WriteHeader(h)
+}
+
+func (w *bufferedHttpResponseWriter) Content() string {
+	return w.buf.String()
+}

--- a/auditing/auditing.go
+++ b/auditing/auditing.go
@@ -1,0 +1,25 @@
+package auditing
+
+import "go.uber.org/zap"
+
+type Config struct {
+	Component        string
+	URL              string
+	APIKey           string
+	IndexPrefix      string
+	RotationInterval Interval
+	Keep             int64
+	Log              *zap.SugaredLogger
+}
+
+type Interval string
+
+var (
+	HourlyInterval  Interval = "@hourly"
+	DailyInterval   Interval = "@daily"
+	MonthlyInterval Interval = "@monthly"
+)
+
+type Auditing interface {
+	Index(...any) error
+}

--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -1,0 +1,180 @@
+package auditing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meilisearch/meilisearch-go"
+	"github.com/robfig/cron"
+	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
+)
+
+type meiliAuditing struct {
+	component        string
+	client           *meilisearch.Client
+	index            *meilisearch.Index
+	log              *zap.SugaredLogger
+	indexPrefix      string
+	rotationInterval Interval
+	keep             int64
+}
+
+func New(c Config) (Auditing, error) {
+	client := meilisearch.NewClient(meilisearch.ClientConfig{
+		Host:   c.URL,
+		APIKey: c.APIKey,
+	})
+	v, err := client.GetVersion()
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to meilisearch at:%s %w", c.URL, err)
+	}
+	c.Log.Infow("meilisearch", "connected to", v, "index rotated", c.RotationInterval, "index keep", c.Keep)
+
+	index := client.Index(c.IndexPrefix)
+	if c.RotationInterval != "" {
+		index = client.Index(indexName(c.IndexPrefix, c.RotationInterval))
+	}
+
+	a := &meiliAuditing{
+		component:        c.Component,
+		client:           client,
+		index:            index,
+		log:              c.Log.Named("auditing"),
+		indexPrefix:      c.IndexPrefix,
+		rotationInterval: c.RotationInterval,
+		keep:             c.Keep,
+	}
+	if a.component == "" {
+		ex, err := os.Executable()
+		if err != nil {
+			return nil, err
+		}
+		a.component = filepath.Base(ex)
+	}
+
+	if c.RotationInterval != "" {
+		// create a new Index every interval
+		cn := cron.New()
+		err := cn.AddFunc(string(c.RotationInterval), a.newIndex)
+		if err != nil {
+			return nil, err
+		}
+		cn.Start()
+	}
+	return a, nil
+}
+
+func (a *meiliAuditing) Index(keysAndValues ...any) error {
+	e := a.toMap(keysAndValues)
+	a.log.Debugw("index", "entry", e)
+	id := uuid.NewString()
+	e["id"] = id
+	e["timestamp"] = time.Now()
+	e["component"] = a.component
+	documents := []map[string]any{e}
+
+	task, err := a.index.AddDocuments(documents)
+	if err != nil {
+		a.log.Errorw("index", "error", err)
+		return err
+	}
+	stats, _ := a.index.GetStats()
+	a.log.Debugw("index", "task status", task.Status, "index stats", stats)
+	return nil
+}
+
+func (a *meiliAuditing) newIndex() {
+	a.log.Debugw("auditing", "create new index", a.rotationInterval)
+	a.index = a.client.Index(indexName(a.indexPrefix, a.rotationInterval))
+	a.cleanUpIndexes()
+}
+
+func (a *meiliAuditing) cleanUpIndexes() {
+	if a.keep == 0 {
+		return
+	}
+	// First get one index to get total amount of indexes
+	indexListResponse, err := a.client.GetIndexes(&meilisearch.IndexesQuery{
+		Limit: 1,
+	})
+	if err != nil {
+		a.log.Errorw("unable to list indexes")
+		return
+	}
+	// Now get all indexes
+	indexListResponse, err = a.client.GetIndexes(&meilisearch.IndexesQuery{
+		Limit: indexListResponse.Total,
+	})
+	if err != nil {
+		a.log.Errorw("unable to list indexes")
+		return
+	}
+
+	a.log.Debugw("indexes listed", "count", indexListResponse.Total, "keep", a.keep)
+
+	// Sort the indexes descending by creation date
+	slices.SortStableFunc(indexListResponse.Results, func(a, b meilisearch.Index) bool {
+		return a.CreatedAt.After(b.CreatedAt)
+	})
+
+	deleted := 0
+	seen := 0
+	for _, index := range indexListResponse.Results {
+		a.log.Debugw("inspect index for deletion", "uid", index.UID)
+		if !strings.HasPrefix(index.UID, a.indexPrefix) {
+			continue
+		}
+		seen++
+		if seen < int(a.keep) {
+			continue
+		}
+		deleteInfo, err := a.client.DeleteIndex(index.UID)
+		if err != nil {
+			a.log.Errorw("unable to delete index", "uid", index.UID, "created", index.CreatedAt)
+			continue
+		}
+		deleted++
+		a.log.Debugw("deleted index", "uid", index.UID, "created", index.CreatedAt, "info", deleteInfo)
+	}
+	a.log.Debugw("done deleting indexes", "deleted", deleted)
+}
+
+func indexName(prefix string, i Interval) string {
+	timeFormat := "2006-01-02"
+
+	switch i {
+	case HourlyInterval:
+		timeFormat = "2006-01-02_15"
+	case DailyInterval:
+		timeFormat = "2006-01-02"
+	case MonthlyInterval:
+		timeFormat = "2006-01"
+	}
+
+	indexName := prefix + "-" + time.Now().Format(timeFormat)
+	return indexName
+}
+
+func (a *meiliAuditing) toMap(args []any) map[string]any {
+	if len(args) == 0 {
+		return nil
+	}
+	if len(args)%2 != 0 {
+		a.log.Errorf("meilisearch pairs of key,value must be provided:%v, not processing", args...)
+		return nil
+	}
+	fields := make(map[string]any)
+	for i := 0; i < len(args); {
+		key, val := args[i], args[i+1]
+		if keyStr, ok := key.(string); ok {
+			fields[keyStr] = val
+		}
+		i += 2
+	}
+	return fields
+}

--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
+	github.com/meilisearch/meilisearch-go v0.23.0
 	github.com/metal-stack/security v0.6.6
 	github.com/metal-stack/v v1.0.3
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/nsqio/nsq v1.2.1
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/robfig/cron v1.2.0
 	github.com/spf13/afero v1.9.4
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
@@ -25,6 +27,7 @@ require (
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/oauth2 v0.5.0
 	golang.org/x/sync v0.1.0
+	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/square/go-jose.v2 v2.6.0
@@ -35,6 +38,7 @@ require (
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
@@ -60,6 +64,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -86,6 +91,8 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.44.0 // indirect
 	go.mongodb.org/mongo-driver v1.11.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
@@ -94,6 +101,7 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,9 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
+github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -158,6 +161,7 @@ github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY9
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -260,6 +264,11 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
+github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -294,6 +303,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/meilisearch/meilisearch-go v0.23.0 h1:CuqB+/NyEJKXF2SovTetAZW7lX+nSH+QTqbgSH6bv+Q=
+github.com/meilisearch/meilisearch-go v0.23.0/go.mod h1:sAPJgywANHUCFUo/spCQ8SoP6sJhmfIKFWIXu7Dd5GQ=
 github.com/metal-stack/security v0.6.6 h1:KSPNN8YZd2EJEjsJ0xCBcd5o53uU0iFupahHA9Twuh0=
 github.com/metal-stack/security v0.6.6/go.mod h1:WchPm3+2Xjj1h7AxM+DsnR9EWgLw+ktoGCl/0gcmgSA=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=
@@ -341,6 +352,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -387,6 +400,12 @@ github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.37.1-0.20220607072126-8a320890c08d/go.mod h1:t/G+3rLek+CyY9bnIE+YlMRddxVAAGjhxndDB4i4C0I=
+github.com/valyala/fasthttp v1.44.0 h1:R+gLUhldIsfg1HokMuQjdQ5bh9nuXHPIfvkYUu9eR5Q=
+github.com/valyala/fasthttp v1.44.0/go.mod h1:f6VbjjoI3z1NDOZOv17o6RvtRSWxC77seBFc2uWtgiY=
+github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
@@ -431,6 +450,7 @@ golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
@@ -506,7 +526,9 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
@@ -583,8 +605,10 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -730,6 +754,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
+google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -746,6 +772,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
+google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Adds the shared auditing functionality to metal-lib.
First step of https://github.com/metal-stack-cloud/docs/issues/95.
