### PR TITLE
Auditing: Lazy index rotation

### DIFF
--- a/auditing/meilisearch_integration_test.go
+++ b/auditing/meilisearch_integration_test.go
@@ -24,7 +24,7 @@ type ConnectionDetails struct {
 }
 
 func StartMeilisearch(t testing.TB) (container testcontainers.Container, c *ConnectionDetails, err error) {
-	meilisearchMasterKey := "meili" // TODO: is this accepted?
+	meilisearchMasterKey := "meili"
 
 	ctx := context.Background()
 	var log testcontainers.Logging
@@ -34,7 +34,7 @@ func StartMeilisearch(t testing.TB) (container testcontainers.Container, c *Conn
 
 	meiliContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "getmeili/meilisearch:v1.1.0",
+			Image:        "getmeili/meilisearch:v1.1.1",
 			ExposedPorts: []string{"7700/tcp"},
 			Env: map[string]string{
 				"MEILI_MASTER_KEY":   meilisearchMasterKey,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/nsqio/nsq v1.2.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/robfig/cron v1.2.0
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Addresses #79 

-  creates an index when writing the first entry - not when booting
- Search now migrates old indexes to latest index settings