### PR TITLE
Consistent request id in auditing interceptors

### DIFF
--- a/auditing/auditing-interceptor.go
+++ b/auditing/auditing-interceptor.go
@@ -85,7 +85,7 @@ func StreamServerInterceptor(a Auditing, logger *zap.SugaredLogger, shouldAudit 
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 		childCtx := context.WithValue(ss.Context(), rest.RequestIDKey, requestID)
 		childSS := grpcServerStreamWithContext{
@@ -143,7 +143,7 @@ func (a auditingConnectInterceptor) WrapStreamingClient(next connect.StreamingCl
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 		childCtx := context.WithValue(ctx, rest.RequestIDKey, requestID)
 
@@ -185,7 +185,7 @@ func (a auditingConnectInterceptor) WrapStreamingHandler(next connect.StreamingH
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 		childCtx := context.WithValue(ctx, rest.RequestIDKey, requestID)
 
@@ -235,7 +235,7 @@ func (i auditingConnectInterceptor) WrapUnary(next connect.UnaryFunc) connect.Un
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 		childCtx := context.WithValue(ctx, rest.RequestIDKey, requestID)
 
@@ -313,7 +313,7 @@ func HttpFilter(a Auditing, logger *zap.SugaredLogger) restful.FilterFunction {
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 		auditReqContext := Entry{
 			RequestId:    requestID,

--- a/auditing/auditing-interceptor.go
+++ b/auditing/auditing-interceptor.go
@@ -33,7 +33,7 @@ func UnaryServerInterceptor(a Auditing, logger *zap.SugaredLogger, shouldAudit f
 			requestID = str
 		}
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 
 		childCtx := context.WithValue(ctx, rest.RequestIDKey, requestID)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -202,7 +202,7 @@ func oidcFlow(appModel *app) error {
 	}
 
 	// generate state
-	appModel.state = uuid.New().String()
+	appModel.state = uuid.NewString()
 
 	clientCtx := oidc.ClientContext(context.Background(), appModel.client)
 

--- a/bus/functools.go
+++ b/bus/functools.go
@@ -86,7 +86,7 @@ func (e *Endpoints) Unique(name string, fn interface{}) (*Function, Func, string
 	if fn == nil {
 		return nil, nil, "", fmt.Errorf("unique function without func is not allowed")
 	}
-	id := uuid.New().String()
+	id := uuid.NewString()
 	topic := name + "-" + id + "#ephemeral"
 	fnc, f, err := e.function(topic, "function#ephemeral", fn)
 	return fnc, f, topic, err

--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -56,7 +56,7 @@ func RequestLoggerFilter(logger *zap.SugaredLogger) restful.FilterFunction {
 
 		requestID := req.HeaderParameter("X-Request-Id")
 		if requestID == "" {
-			requestID = uuid.New().String()
+			requestID = uuid.NewString()
 		}
 
 		fields := []any{


### PR DESCRIPTION
The context with the patched request id wasn't passed into all handler chains.
This might result in missing request ids