### PR TITLE
 fix(auditing): relevant index limit

### DIFF
--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -511,7 +511,7 @@ func (a *meiliAuditing) cleanUpIndexes() error {
 		deleted++
 		a.log.Debugw("deleted index", "uid", index.UID, "created", index.CreatedAt, "info", deleteInfo)
 	}
-	a.log.Infof("cleanup finished", "deletes", deleted, "keep", a.keep, "errs", len(errs))
+	a.log.Infow("cleanup finished", "deletes", deleted, "keep", a.keep, "errs", len(errs))
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}


### PR DESCRIPTION
Due to default pagination, all indexes are ignored after the 20 limits default. This prevented querying indexes after 20 days if the index keep is 0 or >20.

Due to the missing possibility to override the default index keep https://github.com/metal-stack/metal-api/pull/456 this was always the case.