### PR TITLE
Improvements on meilisearch integration tests

### DIFF
--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -160,11 +160,9 @@ func (a *meiliAuditing) Search(filter EntryFilter) ([]Entry, error) {
 
 	reqProto := meilisearch.SearchRequest{
 		Filter: predicates,
-		// as we usually want to have the body be contained regardless of word order, we want to run a phrase search
-		// https://www.meilisearch.com/docs/reference/api/search#phrase-search-2
-		Query: fmt.Sprintf("%q", filter.Body),
-		Sort:  []string{"timestamp-unix:desc", "sort-weight:desc"},
-		Limit: filter.Limit,
+		Query:  filter.Body,
+		Sort:   []string{"timestamp-unix:desc", "sort-weight:desc"},
+		Limit:  filter.Limit,
 	}
 	req := &meilisearch.MultiSearchRequest{
 		Queries: []meilisearch.SearchRequest{},

--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -159,10 +159,11 @@ func (a *meiliAuditing) Search(filter EntryFilter) ([]Entry, error) {
 	}
 
 	reqProto := meilisearch.SearchRequest{
-		Filter: predicates,
-		Query:  filter.Body,
-		Sort:   []string{"timestamp-unix:desc", "sort-weight:desc"},
-		Limit:  filter.Limit,
+		Filter:           predicates,
+		Query:            filter.Body,
+		Sort:             []string{"timestamp-unix:desc", "sort-weight:desc"},
+		Limit:            filter.Limit,
+		MatchingStrategy: "all",
 	}
 	req := &meilisearch.MultiSearchRequest{
 		Queries: []meilisearch.SearchRequest{},

--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -159,11 +159,12 @@ func (a *meiliAuditing) Search(filter EntryFilter) ([]Entry, error) {
 	}
 
 	reqProto := meilisearch.SearchRequest{
-		Filter:           predicates,
-		Query:            filter.Body,
-		Sort:             []string{"timestamp-unix:desc", "sort-weight:desc"},
-		Limit:            filter.Limit,
-		MatchingStrategy: "all",
+		Filter: predicates,
+		// as we usually want to have the body be contained regardless of word order, we want to run a phrase search
+		// https://www.meilisearch.com/docs/reference/api/search#phrase-search-2
+		Query: fmt.Sprintf("%q", filter.Body),
+		Sort:  []string{"timestamp-unix:desc", "sort-weight:desc"},
+		Limit: filter.Limit,
 	}
 	req := &meilisearch.MultiSearchRequest{
 		Queries: []meilisearch.SearchRequest{},

--- a/auditing/meilisearch_integration_test.go
+++ b/auditing/meilisearch_integration_test.go
@@ -260,7 +260,9 @@ func TestAuditing_Meilisearch(t *testing.T) {
 				require.NoError(t, err)
 
 				entries, err := a.Search(EntryFilter{
-					Body: es[0].Body.(string),
+					// we want to run a phrase search as otherwise we return the other entries as well
+					// https://www.meilisearch.com/docs/reference/api/search#phrase-search-2
+					Body: fmt.Sprintf("%q", es[0].Body.(string)),
 				})
 				require.NoError(t, err)
 				require.Len(t, entries, 1)

--- a/auditing/meilisearch_integration_test.go
+++ b/auditing/meilisearch_integration_test.go
@@ -177,4 +177,24 @@ func TestAuditing_Meilisearch(t *testing.T) {
 	require.Equal(t, "global", reqEntry.Tenant)
 	require.Equal(t, auditing.EntryDetail("POST"), reqEntry.Detail)
 	require.Equal(t, "/meilisearch", reqEntry.Path)
+
+	t.Run("body queries", func(t *testing.T) {
+		entries, err = a.Search(auditing.EntryFilter{
+			Body: "not contained in any body",
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 0)
+
+		entries, err = a.Search(auditing.EntryFilter{
+			Body: "you shall not pass",
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		entries, err = a.Search(auditing.EntryFilter{
+			Body: "pass",
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+	})
 }


### PR DESCRIPTION
I was wondering why we get too many results when querying meilisearch:

```
❯ m audit ls --query 4fbfc7c1-40f7-11ee-b2ec-024202390005 --from 2days --no-headers | wc -l
30
❯ m audit ls --query 4fbfc7c1-40f7-11ee-b2ec-024202390005 --from 2days -o yaml | grep 4fbfc7c1-40f7-11ee-b2ec-024202390005 | wc -l
3
```

Therefore I enhanced the tests a bit and found out that with a [phrased search](https://www.meilisearch.com/docs/reference/api/search#phrase-search-2), my search results are in the way I expected them to be. So, this is just enhancing the integration tests.