### PR TITLE
If no route is selected, metal-api crashes with a npe

### DIFF
--- a/auditing/auditing-interceptor.go
+++ b/auditing/auditing-interceptor.go
@@ -309,6 +309,12 @@ func HttpFilter(a Auditing, logger *zap.SugaredLogger) restful.FilterFunction {
 			}
 		}
 
+		if request.SelectedRoute() == nil {
+			logger.Debugw("selected route is not defined, continue request processing")
+			chain.ProcessFilter(request, response)
+			return
+		}
+
 		excluded, ok := request.SelectedRoute().Metadata()[Exclude].(bool)
 		if ok && excluded {
 			logger.Debugw("excluded route from auditing through metadata annotation", "path", request.SelectedRoute().Path())


### PR DESCRIPTION
```
metal-api-876ff9bcb-q4884 metal-api 2023/10/10 11:57:48 http: panic serving 10.44.4.18:34132: runtime error: invalid memory address or nil pointer dereference
metal-api-876ff9bcb-q4884 metal-api goroutine 17614 [running]:
metal-api-876ff9bcb-q4884 metal-api net/http.(*conn).serve.func1()
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:1868 +0xb9
metal-api-876ff9bcb-q4884 metal-api panic({0x169e6a0?, 0x28dc200?})
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/runtime/panic.go:920 +0x270
metal-api-876ff9bcb-q4884 metal-api github.com/metal-stack/metal-lib/auditing.HttpFilter.func1(0xc001161de0, 0xc0004fbc00, 0xc000a9da40?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/metal-stack/metal-lib@v0.13.2/auditing/auditing-interceptor.go:312 +0x197
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x1685d60?, 0xc0000b1680?, 0xc000589a90?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/filter.go:21 +0x42
metal-api-876ff9bcb-q4884 metal-api github.com/metal-stack/metal-api/cmd/metal-api/internal/service.(*TenantEnsurer).EnsureAllowedTenantFilter(0xc0006a3620, 0xc001161de0, 0x4a2801?, 0xc0007f31c0?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/work/metal-api/metal-api/cmd/metal-api/internal/service/service.go:216 +0x19f
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc000b28d00?, 0x1d63060?, 0xc001714660?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/filter.go:21 +0x42
metal-api-876ff9bcb-q4884 metal-api main.initRestServices.UserAuth.func2(0xc001161de0, 0xc0008d7300?, 0x495e6f?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/metal-stack/metal-lib@v0.13.2/rest/middleware.go:137 +0x4c5
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x2a1bbc0?, 0x7ff04688b6e8?, 0x0?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/filter.go:21 +0x42
metal-api-876ff9bcb-q4884 metal-api github.com/metal-stack/metal-api/cmd/metal-api/internal/metrics.RestfulMetrics(0xc001161de0, 0xc0004fbc00, 0x495e01?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/work/metal-api/metal-api/cmd/metal-api/internal/metrics/metrics.go:52 +0x66
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc000b28c00?, 0x1d63060?, 0xc00093be30?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/filter.go:21 +0x42
metal-api-876ff9bcb-q4884 metal-api main.initRestServices.RequestLoggerFilter.func1(0xc001161de0, 0xc0004fbc00, 0xc000c24001?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/metal-stack/metal-lib@v0.13.2/rest/middleware.go:89 +0x4bf
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x1?, 0x1d5f9f0?, 0xc000c240e0?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/filter.go:21 +0x42
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc0004fcf30, {0x1d5f9f0, 0xc000c240e0}, 0xc000b28c00)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/container.go:251 +0x9c9
metal-api-876ff9bcb-q4884 metal-api net/http.HandlerFunc.ServeHTTP(0xc000b24cb0?, {0x1d5f9f0?, 0xc000c240e0?}, 0x29f0be0?)
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:2136 +0x29
metal-api-876ff9bcb-q4884 metal-api net/http.(*ServeMux).ServeHTTP(0x70ed79?, {0x1d5f9f0, 0xc000c240e0}, 0xc000b28c00)
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:2514 +0x142
metal-api-876ff9bcb-q4884 metal-api github.com/emicklei/go-restful/v3.(*Container).ServeHTTP(0x411925?, {0x1d5f9f0?, 0xc000c240e0?}, 0xc000c24001?)
metal-api-876ff9bcb-q4884 metal-api 	/home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.0/container.go:316 +0x1d8
metal-api-876ff9bcb-q4884 metal-api net/http.serverHandler.ServeHTTP({0x1d5a9a0?}, {0x1d5f9f0?, 0xc000c240e0?}, 0x6?)
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:2938 +0x8e
metal-api-876ff9bcb-q4884 metal-api net/http.(*conn).serve(0xc000958000, {0x1d63060, 0xc000339620})
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:2009 +0x5f4
metal-api-876ff9bcb-q4884 metal-api created by net/http.(*Server).Serve in goroutine 1
metal-api-876ff9bcb-q4884 metal-api 	/opt/hostedtoolcache/go/1.21.1/x64/src/net/http/server.go:3086 +0x5cb
```