### PR TITLE
Add `GetOsAndSemverFromImage` function.

### DIFF
--- a/pkg/metal/images.go
+++ b/pkg/metal/images.go
@@ -1,0 +1,35 @@
+package metal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// GetOsAndSemverFromImage parses a metal-api image ID to OS and Semver or returns an error
+//
+// The last part must be the semantic version, valid ids are:
+//
+// ubuntu-19.04                 => os: ubuntu         version: 19.04
+// ubuntu-19.04.20200408        => os: ubuntu         version: 19.04.20200408
+// ubuntu-small-19.04.20200408  => os: ubuntu-small   version: 19.04.20200408
+func GetOsAndSemverFromImage(id string) (string, *semver.Version, error) {
+	imageParts := strings.Split(id, "-")
+	if len(imageParts) < 2 {
+		return "", nil, fmt.Errorf("invalid format for os image, expected <os>-<major>.<minor>[.<patch>]: %s", id)
+	}
+
+	var (
+		parts   = len(imageParts) - 1
+		os      = strings.Join(imageParts[:parts], "-")
+		version = strings.Join(imageParts[parts:], "")
+	)
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return os, v, nil
+}

--- a/pkg/metal/images_test.go
+++ b/pkg/metal/images_test.go
@@ -1,0 +1,63 @@
+package metal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/metal-stack/metal-lib/pkg/testcommon"
+)
+
+func TestGetOsAndSemverFromImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		want       string
+		wantSemver *semver.Version
+		wantErr    error
+	}{
+		{
+			name:       "shorthand syntax",
+			id:         "ubuntu-19.04",
+			want:       "ubuntu",
+			wantSemver: semver.MustParse("19.04"),
+		},
+		{
+			name:       "fqn syntax",
+			id:         "ubuntu-19.04.20200408",
+			want:       "ubuntu",
+			wantSemver: semver.MustParse("19.04.20200408"),
+		},
+		{
+			name:       "dashes in os variant",
+			id:         "ubuntu-slim-19.04.20200408",
+			want:       "ubuntu-slim",
+			wantSemver: semver.MustParse("19.04.20200408"),
+		},
+		{
+			name:    "no version contained",
+			id:      "ubuntu",
+			wantErr: fmt.Errorf("invalid format for os image, expected <os>-<major>.<minor>[.<patch>]: ubuntu"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, sem, err := GetOsAndSemverFromImage(tt.id)
+
+			if diff := cmp.Diff(err, tt.wantErr, testcommon.ErrorStringComparer()); diff != "" {
+				t.Errorf("error diff (+got -want):\n %s", diff)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(v, tt.want); diff != "" {
+				t.Errorf("diff (+got -want):\n %s", diff)
+			}
+			if diff := cmp.Diff(sem, tt.wantSemver); diff != "" {
+				t.Errorf("diff (+got -want):\n %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We need this in many places and it makes sense to share it here.

It's at least used in:

- metal-api
- firewall-controller-manager
- gardener-extension-provider-metal