### PR TITLE
feat(auditing): disables typo tolerance

### DIFF
--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -171,14 +171,14 @@ func (a *meiliAuditing) Search(filter EntryFilter) ([]Entry, error) {
 		filter.Limit = EntryFilterDefaultLimit
 	}
 
-	reqProto := meilisearch.SearchRequest{
+	reqProto := &meilisearch.SearchRequest{
 		Filter: predicates,
 		Query:  filter.Body,
 		Sort:   []string{"timestamp-unix:desc", "sort-weight:desc"},
 		Limit:  filter.Limit,
 	}
 	req := &meilisearch.MultiSearchRequest{
-		Queries: []meilisearch.SearchRequest{},
+		Queries: []*meilisearch.SearchRequest{},
 	}
 
 	_, err := a.getLatestIndex()

--- a/auditing/meilisearch.go
+++ b/auditing/meilisearch.go
@@ -445,14 +445,10 @@ func (a *meiliAuditing) migrateIndexSettings(index *meilisearch.Index) error {
 	}
 	diff := &meilisearch.Settings{}
 
-	// We'd like to disable the typo tolerance completely, but that's not possible, yet.
-	// TypoTolerance.Enabled is marked as omitempty and therefore prevents overriding true with false.
-	// https://github.com/meilisearch/meilisearch-go/issues/452
-	//
-	// if current.TypoTolerance != nil && current.TypoTolerance.Enabled != desired.TypoTolerance.Enabled {
-	// 	changesRequired = true
-	// 	diff.TypoTolerance = desired.TypoTolerance
-	// }
+	if current.TypoTolerance != nil && current.TypoTolerance.Enabled != desired.TypoTolerance.Enabled {
+		changesRequired = true
+		diff.TypoTolerance = desired.TypoTolerance
+	}
 
 	slices.Sort(current.SortableAttributes)
 	slices.Sort(desired.SortableAttributes)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/meilisearch/meilisearch-go v0.27.1
+	github.com/meilisearch/meilisearch-go v0.27.2
 	github.com/metal-stack/security v0.8.0
 	github.com/metal-stack/v v1.0.3
 	github.com/nsqio/go-nsq v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0
 	github.com/mattn/go-isatty v0.0.20
-	github.com/meilisearch/meilisearch-go v0.26.2
+	github.com/meilisearch/meilisearch-go v0.27.1
 	github.com/metal-stack/security v0.8.0
 	github.com/metal-stack/v v1.0.3
 	github.com/nsqio/go-nsq v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
-github.com/meilisearch/meilisearch-go v0.26.2 h1:3gTlmiV1dHHumVUhYdJbvh3camiNiyqQ1hNveVsU2OE=
-github.com/meilisearch/meilisearch-go v0.26.2/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
+github.com/meilisearch/meilisearch-go v0.27.1 h1:9FZfZ9Gy9GQHAfuIpKzubDASH1TJ8HGWVwiju3KKevI=
+github.com/meilisearch/meilisearch-go v0.27.1/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
 github.com/metal-stack/security v0.8.0 h1:tVaSDB9m5clwYrnLyaXfPy7mQlJTnmeoHscG+RUy/xo=
 github.com/metal-stack/security v0.8.0/go.mod h1:7GAcQb+pOgflW30ohJygxpqc3i0dQ2ahGJK1CU5tqa0=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
-github.com/meilisearch/meilisearch-go v0.27.1 h1:9FZfZ9Gy9GQHAfuIpKzubDASH1TJ8HGWVwiju3KKevI=
-github.com/meilisearch/meilisearch-go v0.27.1/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
+github.com/meilisearch/meilisearch-go v0.27.2 h1:3G21dJ5i208shnLPDsIEZ0L0Geg/5oeXABFV7nlK94k=
+github.com/meilisearch/meilisearch-go v0.27.2/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
 github.com/metal-stack/security v0.8.0 h1:tVaSDB9m5clwYrnLyaXfPy7mQlJTnmeoHscG+RUy/xo=
 github.com/metal-stack/security v0.8.0/go.mod h1:7GAcQb+pOgflW30ohJygxpqc3i0dQ2ahGJK1CU5tqa0=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=


### PR DESCRIPTION
meilisearch-go v0.27.1 fixes an issue where the typo tolerance could not be disabled. This should reduce the complexity of indexes but requires a settings migration period for every index.

https://github.com/meilisearch/meilisearch-go/releases/tag/v0.27.1