### PR TITLE
Allow prompt to have a default answer.

### DIFF
--- a/pkg/genericcli/prompt.go
+++ b/pkg/genericcli/prompt.go
@@ -87,7 +87,7 @@ func PromptCustom(c *PromptConfig) error {
 	}
 
 	if c.ShowAnswers {
-		firstCharToUpper := func(s string) string {
+		sentenceCase := func(s string) string {
 			runes := []rune(s)
 			runes[0] = unicode.ToUpper(runes[0])
 			return string(runes)
@@ -98,9 +98,9 @@ func PromptCustom(c *PromptConfig) error {
 
 		if c.DefaultAnswer != "" {
 			if c.DefaultAnswer == c.No {
-				no = firstCharToUpper(c.No)
+				no = sentenceCase(c.No)
 			} else {
-				yes = firstCharToUpper(c.AcceptedAnswers[defaultAnswerIndex])
+				yes = sentenceCase(c.AcceptedAnswers[defaultAnswerIndex])
 			}
 		}
 

--- a/pkg/genericcli/prompt.go
+++ b/pkg/genericcli/prompt.go
@@ -60,6 +60,7 @@ func PromptCustom(c *PromptConfig) error {
 	if len(c.AcceptedAnswers) == 0 {
 		c.AcceptedAnswers = PromptDefaultAnswers()
 		c.DefaultAnswer = pointer.FirstOrZero(c.AcceptedAnswers)
+		c.No = "n"
 	}
 	if c.In == nil {
 		c.In = os.Stdin

--- a/pkg/genericcli/prompt.go
+++ b/pkg/genericcli/prompt.go
@@ -51,6 +51,9 @@ func Prompt() error {
 
 // PromptCustomAnswers the user to given compare text
 func PromptCustom(c *PromptConfig) error {
+	if c == nil {
+		c = promptDefaultConfig()
+	}
 	if c.Message == "" {
 		c.Message = PromptDefaultQuestion()
 	}

--- a/pkg/genericcli/prompt_test.go
+++ b/pkg/genericcli/prompt_test.go
@@ -41,6 +41,18 @@ func TestPromptCustom(t *testing.T) {
 			want: "Do you get it? [Ack/nack] ",
 		},
 		{
+			name:  "custom prompt config, default answer with empty input",
+			input: "\n",
+			c: &PromptConfig{
+				Message:         "Do you get it?",
+				ShowAnswers:     true,
+				AcceptedAnswers: []string{"ack", "a"},
+				DefaultAnswer:   "ack",
+				No:              "nack",
+			},
+			want: "Do you get it? [Ack/nack] ",
+		},
+		{
 			name:  "custom prompt config, default is no answer",
 			input: "ack\n",
 			c: &PromptConfig{

--- a/pkg/genericcli/prompt_test.go
+++ b/pkg/genericcli/prompt_test.go
@@ -1,0 +1,80 @@
+package genericcli
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/metal-stack/metal-lib/pkg/testcommon"
+)
+
+func TestPromptCustom(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       *PromptConfig
+		input   string
+		want    string
+		wantErr error
+	}{
+		{
+			name:  "default prompt config answered with yes",
+			input: "yes\n",
+			want:  "Do you want to continue? [y/n] ",
+		},
+		{
+			name:    "default prompt config answered with no",
+			input:   "no\n",
+			want:    "Do you want to continue? [y/n] ",
+			wantErr: fmt.Errorf(`aborting due to given answer ("no")`),
+		},
+		{
+			name:  "custom prompt config",
+			input: "ack\n",
+			c: &PromptConfig{
+				Message:         "Do you get it?",
+				ShowAnswers:     true,
+				AcceptedAnswers: []string{"ack", "a"},
+				DefaultAnswer:   "ack",
+				No:              "nack",
+			},
+			want: "Do you get it? [Ack/nack] ",
+		},
+		{
+			name:  "custom prompt config, default is no answer",
+			input: "ack\n",
+			c: &PromptConfig{
+				Message:         "Do you get it?",
+				ShowAnswers:     true,
+				AcceptedAnswers: []string{"ack", "a"},
+				DefaultAnswer:   "nack",
+				No:              "nack",
+			},
+			want: "Do you get it? [ack/Nack] ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				in  bytes.Buffer
+				out bytes.Buffer
+			)
+
+			if tt.c == nil {
+				tt.c = promptDefaultConfig()
+			}
+			tt.c.In = &in
+			tt.c.Out = &out
+
+			in.WriteString(tt.input)
+
+			err := PromptCustom(tt.c)
+			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
+				t.Errorf("error diff (+got -want):\n %s", diff)
+			}
+			if diff := cmp.Diff(tt.want, out.String()); diff != "" {
+				t.Errorf("diff (+got -want):\n %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

It's typical for CLI tools to have default answers, which are indicated by capital letters. This PR introduces default answers to our generic CLI prompts.