### PR TITLE
Add a helper to get a unique slice from a tagmap

### DIFF
--- a/jwt/grp/groupcontext.go
+++ b/jwt/grp/groupcontext.go
@@ -14,7 +14,7 @@ import (
 	TenantPrefix:   	Tn = Tenant-Prefix
 	GroupType:			Pg = PermissionGroup
 	SecondLevelOU:		Srv
-	Referenz:			App (App-Permission)
+	Reference:			App (App-Permission)
 	innerGroupName:		kaas-clustername-namespace-role
 	Permission:			Full | Mod | Read
 

--- a/pkg/genericcli/generic.go
+++ b/pkg/genericcli/generic.go
@@ -14,7 +14,7 @@ import (
 // U is the update request for an entity.
 // R is the response object of an entity.
 type GenericCLI[C any, U any, R any] struct {
-	// internally we map everyhing to multi arg cli to reduce code redundance
+	// internally we map everything to multi arg cli to reduce code redundance
 	multiCLI *MultiArgGenericCLI[C, U, R]
 }
 

--- a/pkg/healthstatus/delayed-error-check_test.go
+++ b/pkg/healthstatus/delayed-error-check_test.go
@@ -77,7 +77,7 @@ func TestDelayErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "ignores first error after intial success",
+			name: "ignores first error after initial success",
 			hc: DelayErrors(log, 1, &recordedCheck{
 				name: "record",
 				states: []currentState{

--- a/pkg/tag/helpers.go
+++ b/pkg/tag/helpers.go
@@ -22,6 +22,15 @@ func NewTagMap(labels []string) TagMap {
 	return result
 }
 
+// Slice returns the tagMap as a slice, duplicates removed
+func (tm TagMap) Slice() []string {
+	var result []string
+	for k, v := range tm {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	return result
+}
+
 // Contains returns true when the given key is contained in the label map.
 func (tm TagMap) Contains(key, value string) bool {
 	v, ok := tm[key]

--- a/pkg/tag/helpers_test.go
+++ b/pkg/tag/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/metal-stack/metal-lib/pkg/testcommon"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTagMap_Contains(t *testing.T) {
@@ -173,6 +174,31 @@ func TestTagMap_Get(t *testing.T) {
 			if diff := cmp.Diff(gotValue, tt.wantValue); diff != "" {
 				t.Errorf("TagMap.Get() diff = %s", diff)
 			}
+		})
+	}
+}
+
+func TestTagMap_Slice(t *testing.T) {
+	tests := []struct {
+		name string
+		tm   TagMap
+		want []string
+	}{
+		{
+			name: "no duplicates",
+			tm:   NewTagMap([]string{"color=red", "size=small"}),
+			want: []string{"color=red", "size=small"},
+		},
+		{
+			name: "with duplicates",
+			tm:   NewTagMap([]string{"color=red", "color=red", "size=small"}),
+			want: []string{"color=red", "size=small"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.tm.Slice()
+			require.ElementsMatch(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This enables us to get rid of the tag package in metal-api which is only used in the ip-service.go

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
