### PR TITLE
Fix timescaledb query (missing parenthesis).

### DIFF
--- a/auditing/timescaledb.go
+++ b/auditing/timescaledb.go
@@ -261,7 +261,7 @@ func (a *timescaleAuditing) Search(ctx context.Context, filter EntryFilter) ([]E
 				where = append(where, fmt.Sprintf("entry ->> '%s' like '%%' || :%s || '%%'", field, field))
 			case phrase:
 				// the additional "like" match allows matching partial words, too
-				where = append(where, fmt.Sprintf("ts @@ websearch_to_tsquery('simple', '$$' || :%s || '$$') or entry ->> '%s' like '%%' || :%s || '%%'", field, field, field))
+				where = append(where, fmt.Sprintf("(ts @@ websearch_to_tsquery('simple', '$$' || :%s || '$$') or entry ->> '%s' like '%%' || :%s || '%%')", field, field, field))
 			default:
 				return fmt.Errorf("comp op not known")
 			}

--- a/auditing/timescaledb_integration_test.go
+++ b/auditing/timescaledb_integration_test.go
@@ -350,6 +350,34 @@ func TestAuditing_TimescaleDB(t *testing.T) {
 				require.Len(t, entries, len(testEntries()))
 			},
 		},
+		{
+			name: "filter on query does not affect other filters",
+			t: func(t *testing.T, a Auditing) {
+				es := testEntries()
+				for _, e := range es {
+					err := a.Index(e)
+					require.NoError(t, err)
+				}
+
+				err := a.Flush()
+				require.NoError(t, err)
+
+				entries, err := a.Search(ctx, EntryFilter{
+					From:      now.Add(-1 * time.Minute),
+					To:        now.Add(1 * time.Minute),
+					RequestId: "00000000-0000-0000-0000-000000000000",
+					Phase:     "response",
+					Path:      "/v1/test/0",
+					Body:      "00000000",
+				})
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
+
+				if diff := cmp.Diff(entries[0], es[0]); diff != "" {
+					t.Errorf("diff (+got -want):\n %s", diff)
+				}
+			},
+		},
 	}
 	for i, tt := range tests {
 		tt := tt

--- a/auditing/timescaledb_integration_test.go
+++ b/auditing/timescaledb_integration_test.go
@@ -380,8 +380,6 @@ func TestAuditing_TimescaleDB(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		tt := tt
-
 		t.Run(fmt.Sprintf("%d %s", i, tt.name), func(t *testing.T) {
 			defer func() {
 				a := auditing.(*timescaleAuditing)


### PR DESCRIPTION
## Description

Unfortunately, I forgot parenthesis such that the `body` query field will produce an `or` condition that matches to many results.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
