### PR TITLE
Allow search for status code 0.

### DIFF
--- a/auditing/auditing-interceptor.go
+++ b/auditing/auditing-interceptor.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/google/uuid"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
 	"github.com/metal-stack/metal-lib/rest"
 	"github.com/metal-stack/security"
 	"google.golang.org/grpc"
@@ -494,7 +495,7 @@ func HttpFilter(a Auditing, logger *slog.Logger, opts ...httpFilterOpt) (restful
 		chain.ProcessFilter(request, response)
 
 		auditReqContext.Phase = EntryPhaseResponse
-		auditReqContext.StatusCode = response.StatusCode()
+		auditReqContext.StatusCode = pointer.Pointer(response.StatusCode())
 		strBody := bufferedResponseWriter.Content()
 		body := []byte(strBody)
 		err = json.Unmarshal(body, &auditReqContext.Body)
@@ -547,11 +548,11 @@ func (s grpcServerStreamWithContext) Context() context.Context {
 	return s.ctx
 }
 
-func statusCodeFromGrpc(err error) int {
+func statusCodeFromGrpc(err error) *int {
 	s, ok := status.FromError(err)
 	if !ok {
-		return int(codes.Unknown)
+		return pointer.Pointer(int(codes.Unknown))
 	}
 
-	return int(s.Code())
+	return pointer.Pointer(int(s.Code()))
 }

--- a/auditing/auditing.go
+++ b/auditing/auditing.go
@@ -71,8 +71,8 @@ type Entry struct {
 	ForwardedFor string `json:"forwardedfor"`
 	RemoteAddr   string `json:"remoteaddr"`
 
-	Body       any `json:"body"`       // JSON, string or numbers
-	StatusCode int `json:"statuscode"` // for `EntryDetailHTTP` the HTTP status code, for EntryDetailGRPC` the grpc status code
+	Body       any  `json:"body"`       // JSON, string or numbers
+	StatusCode *int `json:"statuscode"` // for `EntryDetailHTTP` the HTTP status code, for EntryDetailGRPC` the grpc status code
 
 	// Internal errors
 	Error any `json:"error"`
@@ -120,7 +120,7 @@ type EntryFilter struct {
 	RemoteAddr   string `json:"remote_addr" optional:"true"`   // free text
 
 	Body       string `json:"body" optional:"true"`        // free text
-	StatusCode int    `json:"status_code" optional:"true"` // exact match
+	StatusCode *int   `json:"status_code" optional:"true"` // exact match
 
 	Error string `json:"error" optional:"true"` // free text
 }

--- a/auditing/memory.go
+++ b/auditing/memory.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type (
@@ -124,8 +126,8 @@ func (a *memoryAuditing) Search(ctx context.Context, filter EntryFilter) ([]Entr
 	if filter.RequestId != "" {
 		filters = append(filters, func(e Entry) bool { return filter.RequestId == e.RequestId })
 	}
-	if filter.StatusCode != 0 {
-		filters = append(filters, func(e Entry) bool { return filter.StatusCode == e.StatusCode })
+	if filter.StatusCode != nil {
+		filters = append(filters, func(e Entry) bool { return cmp.Equal(filter.StatusCode, e.StatusCode) })
 	}
 	if filter.Tenant != "" {
 		filters = append(filters, func(e Entry) bool { return filter.Tenant == e.Tenant })


### PR DESCRIPTION
## Description

We have an issue with status code zero (which is used by gRPC for  `OK`). It's not possible to search for this specific status code right now because we did not make the field a pointer and the zero value of the status code is also zero.

This change allows the status code to be stored in the database with `nil`. As old records never stored `nil`, it causes old records to be included in the search results.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
